### PR TITLE
Fix demo login password hash

### DIFF
--- a/app/api/auth/login/route.js
+++ b/app/api/auth/login/route.js
@@ -9,7 +9,7 @@ const users = [
     firstName: 'Démo',
     lastName: 'Utilisateur',
     email: 'demo@checkinly.com',
-    password: '$2a$10$N9qo8uLOickgx2ZMRZoMye.j8E5o1FO8wX1rP6ZBOOtIkENPrWHDq', // demo123
+    password: '$2a$10$jLSs2TRYBiH1rn42gXs7ie.rtt94Dszb.w4sF3NvmK/1suZRN.xdG', // demo123
     role: 'owner',
     createdAt: new Date().toISOString()
   }


### PR DESCRIPTION
## Summary
- update the stored bcrypt hash for the demo account to match the advertised password

## Testing
- curl -s -X POST http://localhost:3000/api/auth/login -H 'Content-Type: application/json' -d '{"email":"demo@checkinly.com","password":"demo123"}'

------
https://chatgpt.com/codex/tasks/task_e_68d10b8acf18832eba6d5e594df907d6