### PR TITLE
Add authenticated notifications API and secure client fetch

### DIFF
--- a/app/api/notifications/route.js
+++ b/app/api/notifications/route.js
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { connectDB } from '@/lib/mongodb';
+import { requireAuth } from '@/lib/auth';
+
+export async function GET(request) {
+  try {
+    const user = await requireAuth(request);
+    const { db } = await connectDB();
+
+    const notifications = await db
+      .collection('notifications')
+      .find({ userId: user.id })
+      .sort({ createdAt: -1 })
+      .limit(50)
+      .toArray();
+
+    const formattedNotifications = notifications.map((notification, index) => ({
+      id: notification.id || notification._id?.toString() || `notification-${index}`,
+      title: notification.title || notification.subject || 'Notification',
+      message: notification.message || notification.body || '',
+      type: notification.type || 'info',
+      read: Boolean(notification.read),
+      createdAt: notification.createdAt || notification.timestamp || null,
+      actionUrl: notification.actionUrl || notification.link || null
+    }));
+
+    return NextResponse.json(formattedNotifications);
+  } catch (error) {
+    console.error('Notifications API error:', error);
+    const status =
+      error.message === 'Invalid token' || error.message === 'No token provided'
+        ? 401
+        : 500;
+
+    return NextResponse.json(
+      { message: error.message || 'Erreur lors de la récupération des notifications' },
+      { status }
+    );
+  }
+}

--- a/components/DashboardLayout.js
+++ b/components/DashboardLayout.js
@@ -43,10 +43,23 @@ export default function DashboardLayout({ children }) {
 
   const fetchNotifications = async () => {
     try {
-      const response = await fetch('/api/notifications');
+      const token = localStorage.getItem('auth-token');
+      if (!token) {
+        setNotifications([]);
+        return;
+      }
+
+      const response = await fetch('/api/notifications', {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
       if (response.ok) {
         const data = await response.json();
         setNotifications(data.filter(notif => !notif.read));
+      } else if (response.status === 401) {
+        console.warn('Unauthorized when fetching notifications');
+        setNotifications([]);
       }
     } catch (error) {
       console.error('Error fetching notifications:', error);


### PR DESCRIPTION
## Summary
- add an authenticated `/api/notifications` endpoint that returns the current user's notifications with their read status
- request notifications with the stored bearer token and handle unauthorized responses in the dashboard layout

## Testing
- npm run lint *(fails: existing `react/no-unescaped-entities` violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d112dc3294832e8e92d8de4414a5b2