### PR TITLE
Add inventory duplication API and client error handling

### DIFF
--- a/app/api/inventories/[id]/duplicate/route.js
+++ b/app/api/inventories/[id]/duplicate/route.js
@@ -1,0 +1,96 @@
+import { NextResponse } from 'next/server';
+import { connectDB } from '@/lib/mongodb';
+import { requireAuth } from '@/lib/auth';
+import { v4 as uuidv4 } from 'uuid';
+
+export async function POST(request, { params }) {
+  try {
+    const user = await requireAuth(request);
+    const inventoryId = params?.id;
+
+    if (!inventoryId) {
+      return NextResponse.json(
+        { message: "Identifiant d'inventaire requis" },
+        { status: 400 }
+      );
+    }
+
+    const { db } = await connectDB();
+
+    const existingInventory = await db.collection('inventories').findOne({
+      id: inventoryId,
+      userId: user.id
+    });
+
+    if (!existingInventory) {
+      return NextResponse.json(
+        { message: "Inventaire introuvable" },
+        { status: 404 }
+      );
+    }
+
+    const newInventoryId = uuidv4();
+    const now = new Date();
+    const requestUrl = new URL(request.url);
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || `${requestUrl.protocol}//${requestUrl.host}`;
+
+    const {
+      _id,
+      rooms: existingRooms = [],
+      photos: existingPhotos = [],
+      ...inventoryData
+    } = existingInventory;
+
+    const clonedRooms = Array.isArray(existingRooms)
+      ? existingRooms.map((room) => ({
+          ...room,
+          items: Array.isArray(room.items)
+            ? room.items.map((item) => ({ ...item }))
+            : []
+        }))
+      : [];
+
+    const duplicatedInventory = {
+      ...inventoryData,
+      id: newInventoryId,
+      status: 'pending',
+      progress: 0,
+      qrCodeUrl: `${baseUrl}/inventory/${newInventoryId}/fill`,
+      signature: null,
+      photos: Array.isArray(existingPhotos) ? [...existingPhotos] : [],
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+      rooms: clonedRooms
+    };
+
+    await db.collection('inventories').insertOne(duplicatedInventory);
+
+    await db.collection('activity_logs').insertOne({
+      id: uuidv4(),
+      userId: user.id,
+      type: 'inventory',
+      action: 'duplicated',
+      details: {
+        sourceInventoryId: inventoryId,
+        newInventoryId,
+        propertyId: duplicatedInventory.propertyId,
+        type: duplicatedInventory.type
+      },
+      timestamp: now
+    });
+
+    return NextResponse.json(duplicatedInventory, { status: 201 });
+  } catch (error) {
+    console.error('Inventory duplicate error:', error);
+    return NextResponse.json(
+      { message: error.message || "Erreur lors de la duplication de l'inventaire" },
+      {
+        status:
+          error.message === 'Invalid token' || error.message === 'No token provided'
+            ? 401
+            : 500
+      }
+    );
+  }
+}

--- a/app/inventory/page.js
+++ b/app/inventory/page.js
@@ -23,6 +23,7 @@ export default function InventoryPage() {
   const [inventories, setInventories] = useState([]);
   const [properties, setProperties] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [duplicateError, setDuplicateError] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [propertyFilter, setPropertyFilter] = useState('all');
@@ -95,6 +96,7 @@ export default function InventoryPage() {
   const handleDuplicateInventory = async (inventory) => {
     try {
       const token = localStorage.getItem('auth-token');
+      setDuplicateError(null);
       const response = await fetch(`/api/inventories/${inventory.id}/duplicate`, {
         method: 'POST',
         headers: {
@@ -103,10 +105,23 @@ export default function InventoryPage() {
       });
 
       if (response.ok) {
+        setDuplicateError(null);
         await fetchData();
+      } else {
+        let errorMessage = "Erreur lors de la duplication de l'inventaire";
+        try {
+          const errorData = await response.json();
+          if (errorData?.message) {
+            errorMessage = errorData.message;
+          }
+        } catch (parseError) {
+          console.error('Error parsing duplicate inventory error response:', parseError);
+        }
+        setDuplicateError(errorMessage);
       }
     } catch (error) {
       console.error('Error duplicating inventory:', error);
+      setDuplicateError("Impossible de dupliquer l'inventaire. Veuillez réessayer.");
     }
   };
 
@@ -141,6 +156,12 @@ export default function InventoryPage() {
             Nouvel inventaire
           </button>
         </div>
+
+        {duplicateError && (
+          <div className="rounded-lg border border-danger-200 bg-danger-50 text-danger-700 p-4">
+            {duplicateError}
+          </div>
+        )}
 
         {/* Stats */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">


### PR DESCRIPTION
## Summary
- add an authenticated inventory duplication endpoint that clones nested room/item data, resets audit fields, and logs the action
- surface duplication failures on the inventory list page so users get feedback when cloning fails

## Testing
- npm run lint *(fails: existing `react/no-unescaped-entities` violations in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68d13a9e1f40832e98325ce7e6d1882a