### PR TITLE
Add inventory detail and edit pages with API support

### DIFF
--- a/app/api/inventories/[id]/route.js
+++ b/app/api/inventories/[id]/route.js
@@ -1,0 +1,207 @@
+import { NextResponse } from 'next/server';
+import { connectDB } from '@/lib/mongodb';
+import { requireAuth } from '@/lib/auth';
+import { v4 as uuidv4 } from 'uuid';
+
+export async function GET(request, { params }) {
+  try {
+    const user = await requireAuth(request);
+    const inventoryId = params?.id;
+
+    if (!inventoryId) {
+      return NextResponse.json(
+        { message: "Identifiant d'inventaire requis" },
+        { status: 400 }
+      );
+    }
+
+    const { db } = await connectDB();
+
+    const inventory = await db.collection('inventories').findOne({
+      id: inventoryId,
+      userId: user.id
+    });
+
+    if (!inventory) {
+      return NextResponse.json(
+        { message: "Inventaire introuvable" },
+        { status: 404 }
+      );
+    }
+
+    const { _id, ...inventoryData } = inventory;
+
+    const [property, guest] = await Promise.all([
+      inventory.propertyId
+        ? db.collection('properties').findOne({
+            id: inventory.propertyId,
+            userId: user.id
+          })
+        : Promise.resolve(null),
+      inventory.guestId
+        ? db.collection('guests').findOne({
+            id: inventory.guestId,
+            userId: user.id
+          })
+        : Promise.resolve(null)
+    ]);
+
+    const responseData = {
+      ...inventoryData,
+      propertyName: property?.name || null,
+      propertyAddress: property?.address || null,
+      guest: guest
+        ? {
+            id: guest.id,
+            firstName: guest.firstName,
+            lastName: guest.lastName,
+            email: guest.email || null,
+            phone: guest.phone || null
+          }
+        : null,
+      guestName: guest ? `${guest.firstName} ${guest.lastName}` : null
+    };
+
+    return NextResponse.json(responseData);
+  } catch (error) {
+    console.error('Inventory GET error:', error);
+    return NextResponse.json(
+      { message: error.message || "Erreur lors de la récupération de l'inventaire" },
+      {
+        status:
+          error.message === 'Invalid token' || error.message === 'No token provided'
+            ? 401
+            : 500
+      }
+    );
+  }
+}
+
+export async function PUT(request, { params }) {
+  try {
+    const user = await requireAuth(request);
+    const inventoryId = params?.id;
+
+    if (!inventoryId) {
+      return NextResponse.json(
+        { message: "Identifiant d'inventaire requis" },
+        { status: 400 }
+      );
+    }
+
+    const data = await request.json();
+    const { propertyId, guestId, type, description, dueDate, rooms, status } = data;
+
+    if (!propertyId || !type) {
+      return NextResponse.json(
+        { message: 'PropertyId et type sont requis' },
+        { status: 400 }
+      );
+    }
+
+    const { db } = await connectDB();
+
+    const existingInventory = await db.collection('inventories').findOne({
+      id: inventoryId,
+      userId: user.id
+    });
+
+    if (!existingInventory) {
+      return NextResponse.json(
+        { message: "Inventaire introuvable" },
+        { status: 404 }
+      );
+    }
+
+    const property = await db.collection('properties').findOne({
+      id: propertyId,
+      userId: user.id
+    });
+
+    if (!property) {
+      return NextResponse.json(
+        { message: 'Propriété non trouvée' },
+        { status: 404 }
+      );
+    }
+
+    const updatePayload = {
+      propertyId,
+      guestId: guestId || null,
+      type,
+      description: description?.trim() || '',
+      dueDate: dueDate ? new Date(dueDate) : null,
+      rooms: Array.isArray(rooms) ? rooms : [],
+      status: status || existingInventory.status,
+      updatedAt: new Date()
+    };
+
+    await db.collection('inventories').updateOne(
+      { id: inventoryId, userId: user.id },
+      { $set: updatePayload }
+    );
+
+    const updatedInventory = await db.collection('inventories').findOne({
+      id: inventoryId,
+      userId: user.id
+    });
+
+    const { _id, ...inventoryData } = updatedInventory;
+
+    const [updatedProperty, guest] = await Promise.all([
+      db.collection('properties').findOne({
+        id: inventoryData.propertyId,
+        userId: user.id
+      }),
+      inventoryData.guestId
+        ? db.collection('guests').findOne({
+            id: inventoryData.guestId,
+            userId: user.id
+          })
+        : Promise.resolve(null)
+    ]);
+
+    await db.collection('activity_logs').insertOne({
+      id: uuidv4(),
+      userId: user.id,
+      type: 'inventory',
+      action: 'updated',
+      details: {
+        inventoryId,
+        propertyId: inventoryData.propertyId,
+        propertyName: updatedProperty?.name || null,
+        type: inventoryData.type
+      },
+      timestamp: new Date()
+    });
+
+    const responseData = {
+      ...inventoryData,
+      propertyName: updatedProperty?.name || null,
+      propertyAddress: updatedProperty?.address || null,
+      guest: guest
+        ? {
+            id: guest.id,
+            firstName: guest.firstName,
+            lastName: guest.lastName,
+            email: guest.email || null,
+            phone: guest.phone || null
+          }
+        : null,
+      guestName: guest ? `${guest.firstName} ${guest.lastName}` : null
+    };
+
+    return NextResponse.json(responseData);
+  } catch (error) {
+    console.error('Inventory PUT error:', error);
+    return NextResponse.json(
+      { message: error.message || "Erreur lors de la mise à jour de l'inventaire" },
+      {
+        status:
+          error.message === 'Invalid token' || error.message === 'No token provided'
+            ? 401
+            : 500
+      }
+    );
+  }
+}

--- a/app/inventory/[id]/edit/page.js
+++ b/app/inventory/[id]/edit/page.js
@@ -1,0 +1,727 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import {
+  ArrowLeft,
+  Home,
+  User,
+  FileText,
+  Clock,
+  Plus,
+  Minus,
+  CheckCircle
+} from 'lucide-react';
+import DashboardLayout from '@/components/DashboardLayout';
+
+const STATUS_OPTIONS = [
+  { value: 'pending', label: 'En attente' },
+  { value: 'in_progress', label: 'En cours' },
+  { value: 'completed', label: 'Terminé' },
+  { value: 'archived', label: 'Archivé' }
+];
+
+const ROOM_TYPES = [
+  { value: 'bedroom', label: 'Chambre' },
+  { value: 'living_room', label: 'Salon' },
+  { value: 'kitchen', label: 'Cuisine' },
+  { value: 'bathroom', label: 'Salle de bain' },
+  { value: 'balcony', label: 'Balcon/Terrasse' },
+  { value: 'other', label: 'Autre' }
+];
+
+const formatDateTimeLocal = (value) => {
+  if (!value) return '';
+
+  try {
+    const date = new Date(value);
+    const tzOffset = date.getTimezoneOffset();
+    const localDate = new Date(date.getTime() - tzOffset * 60000);
+    return localDate.toISOString().slice(0, 16);
+  } catch (error) {
+    console.error('Error formatting datetime for input', error);
+    return '';
+  }
+};
+
+export default function EditInventoryPage() {
+  const router = useRouter();
+  const params = useParams();
+  const inventoryId = params?.id;
+
+  const [formData, setFormData] = useState({
+    propertyId: '',
+    guestId: '',
+    type: 'checkin',
+    description: '',
+    dueDate: '',
+    rooms: [],
+    status: 'pending'
+  });
+  const [properties, setProperties] = useState([]);
+  const [guests, setGuests] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState({});
+  const [submitMessage, setSubmitMessage] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token');
+
+    if (!token) {
+      router.replace('/login');
+      return;
+    }
+
+    if (!inventoryId) {
+      setErrors({ submit: "Identifiant d'inventaire manquant" });
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchInitialData = async () => {
+      try {
+        setIsLoading(true);
+        setErrors({});
+        setSubmitMessage('');
+
+        const [inventoryRes, propertiesRes, guestsRes] = await Promise.all([
+          fetch(`/api/inventories/${inventoryId}`, {
+            headers: { Authorization: `Bearer ${token}` }
+          }),
+          fetch('/api/properties', {
+            headers: { Authorization: `Bearer ${token}` }
+          }),
+          fetch('/api/guests', {
+            headers: { Authorization: `Bearer ${token}` }
+          })
+        ]);
+
+        if (inventoryRes.status === 401 || propertiesRes.status === 401 || guestsRes.status === 401) {
+          router.replace('/login');
+          return;
+        }
+
+        if (!inventoryRes.ok) {
+          const errorData = await inventoryRes.json().catch(() => ({}));
+          throw new Error(
+            errorData?.message || "Impossible de charger l'inventaire"
+          );
+        }
+
+        const [inventoryData, propertiesData, guestsData] = await Promise.all([
+          inventoryRes.json(),
+          propertiesRes.ok ? propertiesRes.json() : Promise.resolve([]),
+          guestsRes.ok ? guestsRes.json() : Promise.resolve([])
+        ]);
+
+        setProperties(propertiesData);
+        setGuests(guestsData);
+
+        setFormData({
+          propertyId: inventoryData.propertyId || '',
+          guestId: inventoryData.guestId || '',
+          type: inventoryData.type || 'checkin',
+          description: inventoryData.description || '',
+          dueDate: formatDateTimeLocal(inventoryData.dueDate),
+          rooms: Array.isArray(inventoryData.rooms) ? inventoryData.rooms : [],
+          status: inventoryData.status || 'pending'
+        });
+      } catch (error) {
+        console.error('Error loading inventory data', error);
+        setErrors({ submit: error.message });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchInitialData();
+  }, [inventoryId, router]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value
+    }));
+
+    if (errors[name]) {
+      setErrors((prev) => ({ ...prev, [name]: '' }));
+    }
+  };
+
+  const addRoom = () => {
+    const newRoom = {
+      id: Date.now().toString(),
+      name: '',
+      type: 'bedroom',
+      items: []
+    };
+
+    setFormData((prev) => ({
+      ...prev,
+      rooms: [...prev.rooms, newRoom]
+    }));
+  };
+
+  const removeRoom = (roomId) => {
+    setFormData((prev) => ({
+      ...prev,
+      rooms: prev.rooms.filter((room) => room.id !== roomId)
+    }));
+  };
+
+  const updateRoom = (roomId, field, value) => {
+    setFormData((prev) => ({
+      ...prev,
+      rooms: prev.rooms.map((room) =>
+        room.id === roomId ? { ...room, [field]: value } : room
+      )
+    }));
+  };
+
+  const addItemToRoom = (roomId) => {
+    const newItem = {
+      id: Date.now().toString(),
+      name: '',
+      description: '',
+      condition: 5,
+      photos: [],
+      comments: ''
+    };
+
+    setFormData((prev) => ({
+      ...prev,
+      rooms: prev.rooms.map((room) =>
+        room.id === roomId
+          ? { ...room, items: [...(room.items || []), newItem] }
+          : room
+      )
+    }));
+  };
+
+  const removeItemFromRoom = (roomId, itemId) => {
+    setFormData((prev) => ({
+      ...prev,
+      rooms: prev.rooms.map((room) =>
+        room.id === roomId
+          ? {
+              ...room,
+              items: (room.items || []).filter((item) => item.id !== itemId)
+            }
+          : room
+      )
+    }));
+  };
+
+  const updateRoomItem = (roomId, itemId, field, value) => {
+    setFormData((prev) => ({
+      ...prev,
+      rooms: prev.rooms.map((room) =>
+        room.id === roomId
+          ? {
+              ...room,
+              items: (room.items || []).map((item) =>
+                item.id === itemId ? { ...item, [field]: value } : item
+              )
+            }
+          : room
+      )
+    }));
+  };
+
+  const validateForm = () => {
+    const newErrors = {};
+
+    if (!formData.propertyId) {
+      newErrors.propertyId = 'Propriété requise';
+    }
+
+    if (!formData.type) {
+      newErrors.type = 'Type requis';
+    }
+
+    if (!formData.status) {
+      newErrors.status = 'Statut requis';
+    }
+
+    if (!formData.rooms || formData.rooms.length === 0) {
+      newErrors.rooms = 'Au moins une pièce est requise';
+    }
+
+    formData.rooms.forEach((room, index) => {
+      if (!room.name?.trim()) {
+        newErrors[`room_${index}_name`] = 'Nom de pièce requis';
+      }
+    });
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitMessage('');
+
+    try {
+      const token = localStorage.getItem('auth-token');
+
+      if (!token) {
+        router.replace('/login');
+        return;
+      }
+
+      const response = await fetch(`/api/inventories/${inventoryId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          ...formData,
+          dueDate: formData.dueDate || null
+        })
+      });
+
+      if (response.status === 401) {
+        router.replace('/login');
+        return;
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData?.message || 'Erreur lors de la mise à jour');
+      }
+
+      setSubmitMessage('Inventaire mis à jour avec succès');
+      router.push(`/inventory/${inventoryId}`);
+    } catch (error) {
+      console.error('Error updating inventory', error);
+      setErrors({ submit: error.message });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex items-center space-x-4">
+          <button
+            onClick={() => router.back()}
+            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <ArrowLeft className="h-5 w-5 text-gray-600" />
+          </button>
+          <div>
+              <h1 className="text-2xl font-bold text-gray-900">
+                Modifier l&apos;inventaire
+              </h1>
+            <p className="text-gray-600">
+              Mettez à jour les informations et pièces de cet inventaire
+            </p>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="card flex items-center justify-center h-64">
+            <div className="loading-spinner" aria-label="Chargement" />
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-8">
+            {errors.submit && (
+              <div className="bg-danger-50 border border-danger-200 rounded-lg p-4">
+                <p className="text-danger-700 text-sm">{errors.submit}</p>
+              </div>
+            )}
+
+            {submitMessage && (
+              <div className="bg-success-50 border border-success-200 rounded-lg p-4 flex items-center text-success-700 text-sm">
+                <CheckCircle className="h-4 w-4 mr-2" />
+                {submitMessage}
+              </div>
+            )}
+
+            <div className="card">
+              <h2 className="text-lg font-semibold text-gray-900 mb-6">
+                Informations générales
+              </h2>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                  <label htmlFor="propertyId" className="form-label">
+                    <Home className="h-4 w-4 inline mr-2" />
+                    Propriété *
+                  </label>
+                  <select
+                    id="propertyId"
+                    name="propertyId"
+                    className={`form-input ${errors.propertyId ? 'border-danger-500' : ''}`}
+                    value={formData.propertyId}
+                    onChange={handleChange}
+                    disabled={isSubmitting}
+                    required
+                  >
+                    <option value="">Sélectionnez une propriété</option>
+                    {properties.map((property) => (
+                      <option key={property.id} value={property.id}>
+                        {property.name}
+                      </option>
+                    ))}
+                  </select>
+                  {errors.propertyId && (
+                    <p className="mt-1 text-sm text-danger-600">{errors.propertyId}</p>
+                  )}
+                </div>
+
+                <div>
+                  <label htmlFor="guestId" className="form-label">
+                    <User className="h-4 w-4 inline mr-2" />
+                    Guest (optionnel)
+                  </label>
+                  <select
+                    id="guestId"
+                    name="guestId"
+                    className="form-input"
+                    value={formData.guestId}
+                    onChange={handleChange}
+                    disabled={isSubmitting}
+                  >
+                    <option value="">Aucun guest sélectionné</option>
+                    {guests.map((guest) => (
+                      <option key={guest.id} value={guest.id}>
+                        {guest.firstName} {guest.lastName}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label htmlFor="type" className="form-label">
+                    <FileText className="h-4 w-4 inline mr-2" />
+                    Type d&apos;inventaire *
+                  </label>
+                  <select
+                    id="type"
+                    name="type"
+                    className={`form-input ${errors.type ? 'border-danger-500' : ''}`}
+                    value={formData.type}
+                    onChange={handleChange}
+                    disabled={isSubmitting}
+                    required
+                  >
+                      <option value="checkin">État d&apos;entrée</option>
+                    <option value="checkout">État de sortie</option>
+                  </select>
+                  {errors.type && (
+                    <p className="mt-1 text-sm text-danger-600">{errors.type}</p>
+                  )}
+                </div>
+
+                <div>
+                  <label htmlFor="status" className="form-label">
+                    Statut *
+                  </label>
+                  <select
+                    id="status"
+                    name="status"
+                    className={`form-input ${errors.status ? 'border-danger-500' : ''}`}
+                    value={formData.status}
+                    onChange={handleChange}
+                    disabled={isSubmitting}
+                    required
+                  >
+                    {STATUS_OPTIONS.map((status) => (
+                      <option key={status.value} value={status.value}>
+                        {status.label}
+                      </option>
+                    ))}
+                  </select>
+                  {errors.status && (
+                    <p className="mt-1 text-sm text-danger-600">{errors.status}</p>
+                  )}
+                </div>
+
+                <div>
+                  <label htmlFor="dueDate" className="form-label">
+                    <Clock className="h-4 w-4 inline mr-2" />
+                    Échéance (optionnel)
+                  </label>
+                  <input
+                    id="dueDate"
+                    name="dueDate"
+                    type="datetime-local"
+                    className="form-input"
+                    value={formData.dueDate}
+                    onChange={handleChange}
+                    disabled={isSubmitting}
+                  />
+                </div>
+              </div>
+
+              <div className="mt-6">
+                <label htmlFor="description" className="form-label">
+                  Description
+                </label>
+                <textarea
+                  id="description"
+                  name="description"
+                  rows={3}
+                  className="form-input"
+                  placeholder="Description ou notes sur cet inventaire..."
+                  value={formData.description}
+                  onChange={handleChange}
+                  disabled={isSubmitting}
+                />
+              </div>
+            </div>
+
+            <div className="card">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Pièces de l&apos;inventaire
+                </h2>
+                <button
+                  type="button"
+                  onClick={addRoom}
+                  className="btn-primary flex items-center text-sm"
+                  disabled={isSubmitting}
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Ajouter une pièce
+                </button>
+              </div>
+
+              {errors.rooms && (
+                <div className="bg-danger-50 border border-danger-200 rounded-lg p-4 mb-6">
+                  <p className="text-danger-700 text-sm">{errors.rooms}</p>
+                </div>
+              )}
+
+              {formData.rooms.length === 0 ? (
+                <div className="text-center py-12 bg-gray-50 rounded-lg">
+                  <Home className="h-16 w-16 mx-auto mb-4 text-gray-300" />
+                  <h3 className="text-lg font-medium text-gray-900 mb-2">
+                    Aucune pièce ajoutée
+                  </h3>
+                  <p className="text-gray-600 mb-4">
+                    Ajoutez les pièces pour organiser votre inventaire
+                  </p>
+                  <button
+                    type="button"
+                    onClick={addRoom}
+                    className="btn-primary inline-flex items-center"
+                    disabled={isSubmitting}
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Ajouter une pièce
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  {formData.rooms.map((room, index) => (
+                    <div key={room.id} className="border border-gray-100 rounded-lg p-6">
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1 grid grid-cols-1 md:grid-cols-2 gap-4">
+                          <div>
+                            <label className="form-label">Nom de la pièce *</label>
+                            <input
+                              type="text"
+                              className={`form-input ${errors[`room_${index}_name`] ? 'border-danger-500' : ''}`}
+                              value={room.name}
+                              onChange={(e) =>
+                                updateRoom(room.id, 'name', e.target.value)
+                              }
+                              disabled={isSubmitting}
+                            />
+                            {errors[`room_${index}_name`] && (
+                              <p className="mt-1 text-sm text-danger-600">
+                                {errors[`room_${index}_name`]}
+                              </p>
+                            )}
+                          </div>
+                          <div>
+                            <label className="form-label">Type de pièce</label>
+                            <select
+                              className="form-input"
+                              value={room.type || 'other'}
+                              onChange={(e) =>
+                                updateRoom(room.id, 'type', e.target.value)
+                              }
+                              disabled={isSubmitting}
+                            >
+                              {ROOM_TYPES.map((type) => (
+                                <option key={type.value} value={type.value}>
+                                  {type.label}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => removeRoom(room.id)}
+                          className="ml-4 p-2 text-danger-600 hover:bg-danger-50 rounded-lg"
+                          disabled={isSubmitting}
+                          aria-label="Supprimer la pièce"
+                        >
+                          <Minus className="h-4 w-4" />
+                        </button>
+                      </div>
+
+                      <div className="mt-6 space-y-4">
+                        <div className="flex items-center justify-between">
+                          <h4 className="text-md font-medium text-gray-900">
+                            Éléments de la pièce
+                          </h4>
+                          <button
+                            type="button"
+                            onClick={() => addItemToRoom(room.id)}
+                            className="btn-secondary text-sm"
+                            disabled={isSubmitting}
+                          >
+                            Ajouter un élément
+                          </button>
+                        </div>
+
+                        {(room.items || []).length === 0 ? (
+                          <p className="text-sm text-gray-500">
+                            Aucun élément ajouté pour cette pièce.
+                          </p>
+                        ) : (
+                          <div className="space-y-4">
+                            {room.items.map((item) => (
+                              <div
+                                key={item.id}
+                                className="bg-gray-50 rounded-lg p-4 space-y-3"
+                              >
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                  <div>
+                                    <label className="form-label">Nom</label>
+                                    <input
+                                      type="text"
+                                      className="form-input"
+                                      value={item.name}
+                                      onChange={(e) =>
+                                        updateRoomItem(
+                                          room.id,
+                                          item.id,
+                                          'name',
+                                          e.target.value
+                                        )
+                                      }
+                                      disabled={isSubmitting}
+                                    />
+                                  </div>
+                                  <div>
+                                    <label className="form-label">
+                                      Condition (1 à 5)
+                                    </label>
+                                    <input
+                                      type="number"
+                                      min={1}
+                                      max={5}
+                                      className="form-input"
+                                      value={item.condition ?? 5}
+                                      onChange={(e) =>
+                                        updateRoomItem(
+                                          room.id,
+                                          item.id,
+                                          'condition',
+                                          Number(e.target.value)
+                                        )
+                                      }
+                                      disabled={isSubmitting}
+                                    />
+                                  </div>
+                                </div>
+
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                  <div>
+                                    <label className="form-label">
+                                      Description
+                                    </label>
+                                    <textarea
+                                      className="form-input"
+                                      rows={2}
+                                      value={item.description}
+                                      onChange={(e) =>
+                                        updateRoomItem(
+                                          room.id,
+                                          item.id,
+                                          'description',
+                                          e.target.value
+                                        )
+                                      }
+                                      disabled={isSubmitting}
+                                    />
+                                  </div>
+                                  <div>
+                                    <label className="form-label">
+                                      Commentaires
+                                    </label>
+                                    <textarea
+                                      className="form-input"
+                                      rows={2}
+                                      value={item.comments}
+                                      onChange={(e) =>
+                                        updateRoomItem(
+                                          room.id,
+                                          item.id,
+                                          'comments',
+                                          e.target.value
+                                        )
+                                      }
+                                      disabled={isSubmitting}
+                                    />
+                                  </div>
+                                </div>
+
+                                <div className="text-right">
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      removeItemFromRoom(room.id, item.id)
+                                    }
+                                    className="text-sm text-danger-600 hover:text-danger-700"
+                                    disabled={isSubmitting}
+                                  >
+                                    Supprimer cet élément
+                                  </button>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center justify-end space-x-4">
+              <button
+                type="button"
+                onClick={() => router.push(`/inventory/${inventoryId}`)}
+                className="btn-secondary"
+                disabled={isSubmitting}
+              >
+                Annuler
+              </button>
+              <button type="submit" className="btn-primary" disabled={isSubmitting}>
+                {isSubmitting ? 'Enregistrement...' : 'Enregistrer les modifications'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/inventory/[id]/page.js
+++ b/app/inventory/[id]/page.js
@@ -1,0 +1,370 @@
+'use client';
+
+import { useEffect, useState, useMemo } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import {
+  ArrowLeft,
+  Edit,
+  FileText,
+  Home,
+  User,
+  Calendar,
+  Clock,
+  AlertCircle,
+  CheckCircle,
+  ListChecks
+} from 'lucide-react';
+import { format } from 'date-fns';
+import { fr } from 'date-fns/locale';
+import DashboardLayout from '@/components/DashboardLayout';
+
+const STATUS_CONFIG = {
+  pending: {
+    label: 'En attente',
+    color: 'bg-warning-100 text-warning-800',
+    icon: Clock
+  },
+  in_progress: {
+    label: 'En cours',
+    color: 'bg-primary-100 text-primary-800',
+    icon: ListChecks
+  },
+  completed: {
+    label: 'Terminé',
+    color: 'bg-success-100 text-success-800',
+    icon: CheckCircle
+  },
+  archived: {
+    label: 'Archivé',
+    color: 'bg-gray-100 text-gray-800',
+    icon: FileText
+  }
+};
+
+const TYPE_CONFIG = {
+  checkin: {
+    label: "État d'entrée",
+    color: 'text-success-600'
+  },
+  checkout: {
+    label: 'État de sortie',
+    color: 'text-danger-600'
+  }
+};
+
+const formatDate = (date, withTime = false) => {
+  if (!date) return '—';
+
+  try {
+    return format(new Date(date), withTime ? 'd MMM yyyy HH:mm' : 'd MMM yyyy', {
+      locale: fr
+    });
+  } catch (error) {
+    console.error('Error formatting date', error);
+    return '—';
+  }
+};
+
+export default function InventoryDetailsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const inventoryId = params?.id;
+
+  const [inventory, setInventory] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token');
+
+    if (!token) {
+      router.replace('/login');
+      return;
+    }
+
+    if (!inventoryId) {
+      setError("Identifiant d'inventaire manquant");
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchInventory = async () => {
+      try {
+        setIsLoading(true);
+        setError('');
+
+        const response = await fetch(`/api/inventories/${inventoryId}`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+
+        if (response.status === 401) {
+          router.replace('/login');
+          return;
+        }
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(
+            errorData?.message || "Impossible de récupérer l'inventaire"
+          );
+        }
+
+        const data = await response.json();
+        setInventory(data);
+      } catch (fetchError) {
+        console.error('Error fetching inventory', fetchError);
+        setError(fetchError.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchInventory();
+  }, [inventoryId, router]);
+
+  const statusConfig = useMemo(() => {
+    if (!inventory?.status) {
+      return {
+        label: 'Statut inconnu',
+        color: 'bg-gray-100 text-gray-800',
+        icon: AlertCircle
+      };
+    }
+
+    return STATUS_CONFIG[inventory.status] ?? {
+      label: inventory.status,
+      color: 'bg-gray-100 text-gray-800',
+      icon: AlertCircle
+    };
+  }, [inventory?.status]);
+
+  const typeConfig = TYPE_CONFIG[inventory?.type] ?? {
+    label: 'Général',
+    color: 'text-gray-600'
+  };
+
+  const StatusIcon = statusConfig.icon;
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-5xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-4">
+            <button
+              onClick={() => router.back()}
+              className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            >
+              <ArrowLeft className="h-5 w-5 text-gray-600" />
+            </button>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">
+                Inventaire #{inventoryId}
+              </h1>
+              <p className="text-gray-600">
+                Consultez les détails complets de cet inventaire
+              </p>
+            </div>
+          </div>
+
+          {inventory && (
+            <button
+              onClick={() => router.push(`/inventory/${inventoryId}/edit`)}
+              className="btn-primary inline-flex items-center"
+            >
+              <Edit className="h-4 w-4 mr-2" />
+              Modifier
+            </button>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="card flex items-center justify-center h-64">
+            <div className="loading-spinner" aria-label="Chargement" />
+          </div>
+        ) : error ? (
+          <div className="card bg-danger-50 border border-danger-200 text-danger-700">
+            {error}
+          </div>
+        ) : !inventory ? (
+          <div className="card text-center py-12">
+            <FileText className="h-16 w-16 mx-auto mb-4 text-gray-300" />
+            <h2 className="text-xl font-semibold text-gray-900 mb-2">
+              Inventaire introuvable
+            </h2>
+              <p className="text-gray-600 mb-6">
+                Vérifiez l&apos;identifiant ou retournez à la liste des inventaires.
+              </p>
+            <button
+              onClick={() => router.push('/inventory')}
+              className="btn-primary"
+            >
+              Retour à la liste
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <div className="card">
+              <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+                <div>
+                  <div className="flex items-center space-x-2 mb-2">
+                    <Home className="h-5 w-5 text-primary-600" />
+                    <span className="text-lg font-semibold text-gray-900">
+                      {inventory.propertyName || 'Propriété inconnue'}
+                    </span>
+                  </div>
+                  {inventory.propertyAddress && (
+                    <p className="text-sm text-gray-600">
+                      {inventory.propertyAddress}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className={`badge ${statusConfig.color} flex items-center`}>
+                    <StatusIcon className="h-3 w-3 mr-1" />
+                    {statusConfig.label}
+                  </span>
+                  <span className={`text-sm font-medium ${typeConfig.color}`}>
+                    {typeConfig.label}
+                  </span>
+                </div>
+              </div>
+
+              <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div className="flex items-center text-gray-600">
+                  <Calendar className="h-4 w-4 mr-2" />
+                  Créé le
+                  <span className="ml-auto font-medium text-gray-900">
+                    {formatDate(inventory.createdAt)}
+                  </span>
+                </div>
+                <div className="flex items-center text-gray-600">
+                  <Calendar className="h-4 w-4 mr-2" />
+                  Dernière mise à jour
+                  <span className="ml-auto font-medium text-gray-900">
+                    {formatDate(inventory.updatedAt, true)}
+                  </span>
+                </div>
+                <div className="flex items-center text-gray-600">
+                  <Clock className="h-4 w-4 mr-2" />
+                  Échéance
+                  <span
+                    className={`ml-auto font-medium ${
+                      inventory.dueDate && new Date(inventory.dueDate) < new Date()
+                        ? 'text-danger-600'
+                        : 'text-gray-900'
+                    }`}
+                  >
+                    {formatDate(inventory.dueDate, true)}
+                  </span>
+                </div>
+              </div>
+
+              {inventory.description && (
+                <div className="mt-6">
+                  <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+                    Description
+                  </h3>
+                  <p className="mt-2 text-gray-700 leading-relaxed">
+                    {inventory.description}
+                  </p>
+                </div>
+              )}
+
+              {inventory.guest && (
+                <div className="mt-6">
+                  <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+                    Guest associé
+                  </h3>
+                  <div className="mt-3 flex flex-col sm:flex-row sm:items-center sm:justify-between bg-gray-50 rounded-lg p-4">
+                    <div className="flex items-center text-gray-700">
+                      <User className="h-5 w-5 mr-3 text-primary-600" />
+                      <div>
+                        <p className="font-medium">
+                          {inventory.guest.firstName} {inventory.guest.lastName}
+                        </p>
+                        {inventory.guest.email && (
+                          <p className="text-sm text-gray-500">{inventory.guest.email}</p>
+                        )}
+                      </div>
+                    </div>
+                    {inventory.guest.phone && (
+                      <p className="mt-2 sm:mt-0 text-sm text-gray-600">
+                        Tél : {inventory.guest.phone}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="card">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Pièces et éléments vérifiés
+                </h2>
+                <span className="text-sm text-gray-600">
+                  {inventory.rooms?.length || 0} pièce(s)
+                </span>
+              </div>
+
+              {(!inventory.rooms || inventory.rooms.length === 0) && (
+                <div className="text-center py-10 text-gray-600">
+                  Aucune pièce enregistrée pour cet inventaire.
+                </div>
+              )}
+
+              <div className="space-y-6">
+                {inventory.rooms?.map((room) => (
+                  <div key={room.id} className="border border-gray-100 rounded-lg p-5">
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                      <div>
+                        <h3 className="text-md font-semibold text-gray-900">
+                          {room.name || 'Pièce sans nom'}
+                        </h3>
+                        <p className="text-sm text-gray-500 capitalize">
+                          {room.type || 'type inconnu'}
+                        </p>
+                      </div>
+                      <span className="text-sm text-gray-600">
+                        {room.items?.length || 0} élément(s)
+                      </span>
+                    </div>
+
+                    {room.items && room.items.length > 0 && (
+                      <div className="mt-4 space-y-3">
+                        {room.items.map((item) => (
+                          <div
+                            key={item.id}
+                            className="bg-gray-50 rounded-lg p-4 text-sm text-gray-700"
+                          >
+                            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                              <p className="font-medium text-gray-900">
+                                {item.name || 'Élément sans nom'}
+                              </p>
+                              <span className="text-gray-600">
+                                Condition : {item.condition ?? '—'}/5
+                              </span>
+                            </div>
+                            {item.description && (
+                              <p className="mt-2 text-gray-600">{item.description}</p>
+                            )}
+                            {item.comments && (
+                              <p className="mt-2 text-gray-500 italic">
+                                Commentaires : {item.comments}
+                              </p>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated API route for inventory detail retrieval and updates with authentication
- create inventory detail and edit pages that load data from the API and enforce auth redirects
- build a prefilled edit form for rooms/items that saves changes back to the API

## Testing
- npm run lint *(fails: pre-existing react/no-unescaped-entities warnings in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d13c673170832e8bf40d1297eb73da