### PR TITLE
Add property detail and settings pages

### DIFF
--- a/app/api/properties/[id]/route.js
+++ b/app/api/properties/[id]/route.js
@@ -4,6 +4,110 @@ import { requireAuth } from '@/lib/auth';
 import { v4 as uuidv4 } from 'uuid';
 import { validateAndNormalizePropertyPayload } from '../utils';
 
+function normalizeSettingsPayload(settings = {}, existingSettings = {}) {
+  const {
+    autoCheckIn,
+    requireDeposit,
+    depositAmount,
+    cleaningFee,
+    accessCode,
+    checkInTime,
+    checkOutTime
+  } = settings;
+
+  const normalized = {};
+
+  if (autoCheckIn !== undefined) {
+    normalized.autoCheckIn = Boolean(autoCheckIn);
+  }
+
+  if (requireDeposit !== undefined) {
+    normalized.requireDeposit = Boolean(requireDeposit);
+  }
+
+  if (depositAmount !== undefined) {
+    const amount = parseFloat(depositAmount);
+    if (Number.isNaN(amount) || amount < 0) {
+      return {
+        errorResponse: NextResponse.json(
+          { message: 'Le montant de dépôt doit être un nombre positif ou nul' },
+          { status: 400 }
+        )
+      };
+    }
+    normalized.depositAmount = amount;
+  }
+
+  if (cleaningFee !== undefined) {
+    const fee = parseFloat(cleaningFee);
+    if (Number.isNaN(fee) || fee < 0) {
+      return {
+        errorResponse: NextResponse.json(
+          { message: 'Les frais de ménage doivent être un nombre positif ou nul' },
+          { status: 400 }
+        )
+      };
+    }
+    normalized.cleaningFee = fee;
+  }
+
+  if (accessCode !== undefined) {
+    normalized.accessCode = String(accessCode).trim();
+  }
+
+  if (checkInTime !== undefined) {
+    normalized.checkInTime = String(checkInTime);
+  }
+
+  if (checkOutTime !== undefined) {
+    normalized.checkOutTime = String(checkOutTime);
+  }
+
+  if (Object.keys(normalized).length === 0) {
+    return { normalizedSettings: existingSettings };
+  }
+
+  return {
+    normalizedSettings: {
+      ...existingSettings,
+      ...normalized
+    }
+  };
+}
+
+export async function GET(request, { params }) {
+  try {
+    const user = await requireAuth(request);
+    const { id } = params || {};
+
+    if (!id) {
+      return NextResponse.json(
+        { message: 'Identifiant de propriété manquant' },
+        { status: 400 }
+      );
+    }
+
+    const { db } = await connectDB();
+
+    const property = await db.collection('properties').findOne({ id, userId: user.id });
+
+    if (!property) {
+      return NextResponse.json(
+        { message: 'Propriété introuvable' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(property);
+  } catch (error) {
+    console.error('Property GET error:', error);
+    return NextResponse.json(
+      { message: error.message || 'Erreur lors de la récupération de la propriété' },
+      { status: error.message === 'Invalid token' || error.message === 'No token provided' ? 401 : 500 }
+    );
+  }
+}
+
 export async function PUT(request, { params }) {
   try {
     const user = await requireAuth(request);
@@ -16,32 +120,62 @@ export async function PUT(request, { params }) {
       );
     }
 
-    const data = await request.json();
-    const { errorResponse, normalizedData } = validateAndNormalizePropertyPayload(data);
-
-    if (errorResponse) {
-      return errorResponse;
-    }
-
     const { db } = await connectDB();
 
-    const updateResult = await db.collection('properties').findOneAndUpdate(
-      { id, userId: user.id },
-      {
-        $set: {
-          ...normalizedData,
-          updatedAt: new Date()
-        }
-      },
-      { returnDocument: 'after' }
-    );
+    const existingProperty = await db.collection('properties').findOne({ id, userId: user.id });
 
-    if (!updateResult.value) {
+    if (!existingProperty) {
       return NextResponse.json(
         { message: 'Propriété introuvable' },
         { status: 404 }
       );
     }
+
+    const data = await request.json();
+    const { settings, ...propertyData } = data || {};
+
+    let updatePayload = {};
+
+    if (Object.keys(propertyData).length > 0) {
+      const { errorResponse, normalizedData } = validateAndNormalizePropertyPayload(propertyData);
+
+      if (errorResponse) {
+        return errorResponse;
+      }
+
+      updatePayload = { ...updatePayload, ...normalizedData };
+    }
+
+    if (settings !== undefined) {
+      const { errorResponse, normalizedSettings } = normalizeSettingsPayload(
+        settings,
+        existingProperty.settings || {}
+      );
+
+      if (errorResponse) {
+        return errorResponse;
+      }
+
+      updatePayload = { ...updatePayload, settings: normalizedSettings };
+    }
+
+    if (Object.keys(updatePayload).length === 0) {
+      return NextResponse.json(
+        { message: "Aucune donnée valide fournie pour la mise à jour" },
+        { status: 400 }
+      );
+    }
+
+    const updateResult = await db.collection('properties').findOneAndUpdate(
+      { id, userId: user.id },
+      {
+        $set: {
+          ...updatePayload,
+          updatedAt: new Date()
+        }
+      },
+      { returnDocument: 'after' }
+    );
 
     await db.collection('activity_logs').insertOne({
       id: uuidv4(),

--- a/app/properties/[id]/page.js
+++ b/app/properties/[id]/page.js
@@ -1,0 +1,287 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  ArrowLeft,
+  Home,
+  MapPin,
+  Users,
+  Bed,
+  Bath,
+  Settings,
+  Calendar,
+  Key
+} from 'lucide-react';
+import DashboardLayout from '@/components/DashboardLayout';
+
+const PROPERTY_TYPE_LABELS = {
+  apartment: 'Appartement',
+  house: 'Maison',
+  studio: 'Studio',
+  villa: 'Villa',
+  loft: 'Loft',
+  room: 'Chambre'
+};
+
+export default function PropertyDetailsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const propertyId = params?.id;
+  const [property, setProperty] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchProperty = async () => {
+      if (!propertyId) {
+        return;
+      }
+
+      const token = localStorage.getItem('auth-token');
+
+      if (!token) {
+        router.replace('/login');
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await fetch(`/api/properties/${propertyId}`, {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        });
+
+        if (response.status === 401) {
+          router.replace('/login');
+          return;
+        }
+
+        if (!response.ok) {
+          const message = response.status === 404
+            ? 'Propriété introuvable'
+            : 'Impossible de charger la propriété';
+          setError(message);
+          return;
+        }
+
+        const data = await response.json();
+        setProperty(data);
+      } catch (err) {
+        console.error('Error loading property:', err);
+        setError('Impossible de charger la propriété');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchProperty();
+  }, [propertyId, router]);
+
+  const handleGoBack = () => {
+    router.push('/properties');
+  };
+
+  const handleOpenSettings = () => {
+    if (property?.id) {
+      router.push(`/properties/${property.id}/settings`);
+    }
+  };
+
+  const handleOpenCalendar = () => {
+    if (property?.id) {
+      router.push(`/calendar?property=${property.id}`);
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <button
+            onClick={handleGoBack}
+            className="inline-flex items-center text-sm font-medium text-gray-600 hover:text-gray-900"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Retour aux propriétés
+          </button>
+
+          {property && (
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleOpenCalendar}
+                className="btn-secondary inline-flex items-center"
+              >
+                <Calendar className="mr-2 h-4 w-4" />
+                Calendrier
+              </button>
+              <button
+                onClick={handleOpenSettings}
+                className="btn-primary inline-flex items-center"
+              >
+                <Settings className="mr-2 h-4 w-4" />
+                Paramètres
+              </button>
+            </div>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="card flex h-64 items-center justify-center">
+            <div className="loading-spinner" />
+          </div>
+        ) : error ? (
+          <div className="card border-danger-200 bg-danger-50 text-danger-700">
+            <p>{error}</p>
+          </div>
+        ) : property ? (
+          <div className="space-y-6">
+            <div className="card">
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <div className="flex items-center gap-3">
+                    <Home className="h-8 w-8 text-primary-600" />
+                    <div>
+                      <h1 className="text-2xl font-bold text-gray-900">{property.name}</h1>
+                      <p className="text-gray-600">{PROPERTY_TYPE_LABELS[property.type] ?? property.type}</p>
+                    </div>
+                  </div>
+                  {property.description && (
+                    <p className="mt-4 text-gray-600">{property.description}</p>
+                  )}
+                </div>
+                <div className="rounded-lg border border-primary-200 bg-primary-50 px-4 py-3 text-primary-700">
+                  <p className="text-sm font-medium uppercase tracking-wide">Statut</p>
+                  <p className="text-lg font-semibold">
+                    {property.status === 'inactive' ? 'Inactive' : 'Active'}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+              <div className="card space-y-4">
+                <h2 className="text-lg font-semibold text-gray-900">Informations principales</h2>
+                <div className="space-y-3">
+                  <div className="flex items-start gap-3">
+                    <MapPin className="mt-1 h-5 w-5 text-primary-600" />
+                    <div>
+                      <p className="text-sm font-medium text-gray-700">Adresse</p>
+                      <p className="text-gray-600">{property.address}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <Users className="mt-1 h-5 w-5 text-primary-600" />
+                    <div>
+                      <p className="text-sm font-medium text-gray-700">Capacité maximale</p>
+                      <p className="text-gray-600">{property.maxGuests} invité(s)</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <Bed className="mt-1 h-5 w-5 text-primary-600" />
+                    <div>
+                      <p className="text-sm font-medium text-gray-700">Chambres</p>
+                      <p className="text-gray-600">{property.bedrooms}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <Bath className="mt-1 h-5 w-5 text-primary-600" />
+                    <div>
+                      <p className="text-sm font-medium text-gray-700">Salles de bain</p>
+                      <p className="text-gray-600">{property.bathrooms}</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="card space-y-4">
+                <h2 className="text-lg font-semibold text-gray-900">Paramètres rapides</h2>
+                <div className="space-y-3 text-gray-600">
+                  <p>
+                    <span className="font-medium text-gray-700">Check-in :</span>{' '}
+                    {property.settings?.checkInTime || 'Non défini'}
+                  </p>
+                  <p>
+                    <span className="font-medium text-gray-700">Check-out :</span>{' '}
+                    {property.settings?.checkOutTime || 'Non défini'}
+                  </p>
+                  <p className="flex items-center gap-2">
+                    <Key className="h-4 w-4 text-primary-600" />
+                    <span>
+                      Code d&apos;accès : {property.settings?.accessCode || 'Non défini'}
+                    </span>
+                  </p>
+                  <p>
+                    <span className="font-medium text-gray-700">Dépôt :</span>{' '}
+                    {property.settings?.requireDeposit
+                      ? `${property.settings?.depositAmount ?? 0} €`
+                      : 'Non requis'}
+                  </p>
+                  <p>
+                    <span className="font-medium text-gray-700">Frais de ménage :</span>{' '}
+                    {property.settings?.cleaningFee != null
+                      ? `${property.settings.cleaningFee} €`
+                      : 'Non défini'}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {(property.amenities?.length ?? 0) > 0 && (
+              <div className="card">
+                <h2 className="text-lg font-semibold text-gray-900">Équipements</h2>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {property.amenities.map((amenity) => (
+                    <span
+                      key={amenity}
+                      className="rounded-full bg-primary-50 px-3 py-1 text-sm font-medium text-primary-700"
+                    >
+                      {amenity}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {property.stats && (
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-4">
+                <div className="card text-center">
+                  <p className="text-sm font-medium text-gray-600">Réservations</p>
+                  <p className="text-2xl font-semibold text-gray-900">
+                    {property.stats.totalBookings ?? 0}
+                  </p>
+                </div>
+                <div className="card text-center">
+                  <p className="text-sm font-medium text-gray-600">Revenus</p>
+                  <p className="text-2xl font-semibold text-gray-900">
+                    {property.stats.totalRevenue ?? 0} €
+                  </p>
+                </div>
+                <div className="card text-center">
+                  <p className="text-sm font-medium text-gray-600">Note moyenne</p>
+                  <p className="text-2xl font-semibold text-gray-900">
+                    {property.stats.averageRating ?? 0} / 5
+                  </p>
+                </div>
+                <div className="card text-center">
+                  <p className="text-sm font-medium text-gray-600">Taux d&apos;occupation</p>
+                  <p className="text-2xl font-semibold text-gray-900">
+                    {property.stats.occupancyRate ?? 0}%
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="card">
+            <p className="text-gray-600">Propriété introuvable.</p>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}
+

--- a/app/properties/[id]/settings/page.js
+++ b/app/properties/[id]/settings/page.js
@@ -1,0 +1,372 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft, Save, ShieldCheck, Clock, Key } from 'lucide-react';
+import DashboardLayout from '@/components/DashboardLayout';
+
+const DEFAULT_SETTINGS = {
+  autoCheckIn: true,
+  requireDeposit: true,
+  depositAmount: 0,
+  cleaningFee: 0,
+  accessCode: '',
+  checkInTime: '15:00',
+  checkOutTime: '11:00'
+};
+
+export default function PropertySettingsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const [property, setProperty] = useState(null);
+  const [formData, setFormData] = useState(DEFAULT_SETTINGS);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [fetchError, setFetchError] = useState(null);
+  const [saveError, setSaveError] = useState(null);
+  const [success, setSuccess] = useState(false);
+  const [token, setToken] = useState(null);
+
+  const propertyId = params?.id;
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem('auth-token');
+
+    if (!storedToken) {
+      router.replace('/login');
+      return;
+    }
+
+    setToken(storedToken);
+  }, [router]);
+
+  useEffect(() => {
+    if (!propertyId || !token) {
+      return;
+    }
+
+    const fetchProperty = async () => {
+      try {
+        setIsLoading(true);
+        setFetchError(null);
+
+        const response = await fetch(`/api/properties/${propertyId}`, {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        });
+
+        if (response.status === 401) {
+          router.replace('/login');
+          return;
+        }
+
+        if (!response.ok) {
+          const message = response.status === 404
+            ? 'Propriété introuvable'
+            : 'Impossible de charger la propriété';
+          setFetchError(message);
+          return;
+        }
+
+        const data = await response.json();
+        setProperty(data);
+
+        const settings = {
+          ...DEFAULT_SETTINGS,
+          ...data.settings
+        };
+
+        setFormData({
+          autoCheckIn: Boolean(settings.autoCheckIn),
+          requireDeposit: Boolean(settings.requireDeposit),
+          depositAmount: Number(settings.depositAmount ?? 0),
+          cleaningFee: Number(settings.cleaningFee ?? 0),
+          accessCode: settings.accessCode ?? '',
+          checkInTime: settings.checkInTime ?? DEFAULT_SETTINGS.checkInTime,
+          checkOutTime: settings.checkOutTime ?? DEFAULT_SETTINGS.checkOutTime
+        });
+      } catch (err) {
+        console.error('Error loading property settings:', err);
+        setFetchError('Impossible de charger la propriété');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchProperty();
+  }, [propertyId, router, token]);
+
+  const handleGoBack = () => {
+    router.push(property ? `/properties/${property.id}` : '/properties');
+  };
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: name === 'accessCode' || name === 'checkInTime' || name === 'checkOutTime'
+        ? value
+        : Number(value)
+    }));
+  };
+
+  const handleToggle = (event) => {
+    const { name, checked } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: checked
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!propertyId || !token) {
+      router.replace('/login');
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      setSaveError(null);
+      setSuccess(false);
+
+      const response = await fetch(`/api/properties/${propertyId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          settings: {
+            ...formData,
+            depositAmount: formData.requireDeposit ? formData.depositAmount : 0
+          }
+        })
+      });
+
+      if (response.status === 401) {
+        router.replace('/login');
+        return;
+      }
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        setSaveError(errorData?.message || 'Impossible de sauvegarder les paramètres');
+        return;
+      }
+
+      const updated = await response.json();
+      setProperty(updated);
+      setSaveError(null);
+      setSuccess(true);
+    } catch (err) {
+      console.error('Error saving property settings:', err);
+      setSaveError('Impossible de sauvegarder les paramètres');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <button
+            onClick={handleGoBack}
+            className="inline-flex items-center text-sm font-medium text-gray-600 hover:text-gray-900"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Retour
+          </button>
+        </div>
+
+        {isLoading ? (
+          <div className="card flex h-64 items-center justify-center">
+            <div className="loading-spinner" />
+          </div>
+        ) : fetchError ? (
+          <div className="card border-danger-200 bg-danger-50 text-danger-700">
+            <p>{fetchError}</p>
+          </div>
+        ) : property ? (
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="card">
+              <h1 className="text-2xl font-bold text-gray-900">Paramètres de {property.name}</h1>
+              <p className="mt-2 text-gray-600">
+                Ajustez les paramètres opérationnels de votre propriété.
+              </p>
+            </div>
+
+            {success && (
+              <div className="rounded-lg border border-success-200 bg-success-50 px-4 py-3 text-success-700">
+                Les paramètres ont été mis à jour avec succès.
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                <section className="card space-y-6">
+                  <div className="flex items-center gap-3">
+                    <Clock className="h-6 w-6 text-primary-600" />
+                    <h2 className="text-lg font-semibold text-gray-900">Horaires d&apos;arrivée et de départ</h2>
+                  </div>
+
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label htmlFor="checkInTime" className="form-label">Heure de check-in</label>
+                    <input
+                      id="checkInTime"
+                      name="checkInTime"
+                      type="time"
+                      className="form-input"
+                      value={formData.checkInTime}
+                      onChange={handleInputChange}
+                      disabled={isSaving}
+                    />
+                  </div>
+
+                  <div>
+                    <label htmlFor="checkOutTime" className="form-label">Heure de check-out</label>
+                    <input
+                      id="checkOutTime"
+                      name="checkOutTime"
+                      type="time"
+                      className="form-input"
+                      value={formData.checkOutTime}
+                      onChange={handleInputChange}
+                      disabled={isSaving}
+                    />
+                  </div>
+                </div>
+
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    name="autoCheckIn"
+                    className="form-checkbox"
+                    checked={formData.autoCheckIn}
+                    onChange={handleToggle}
+                    disabled={isSaving}
+                  />
+                  <span className="text-sm text-gray-700">Activation automatique du check-in</span>
+                </label>
+              </section>
+
+              <section className="card space-y-6">
+                <div className="flex items-center gap-3">
+                  <ShieldCheck className="h-6 w-6 text-primary-600" />
+                  <h2 className="text-lg font-semibold text-gray-900">Dépôt et sécurité</h2>
+                </div>
+
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    name="requireDeposit"
+                    className="form-checkbox"
+                    checked={formData.requireDeposit}
+                    onChange={handleToggle}
+                    disabled={isSaving}
+                  />
+                  <span className="text-sm text-gray-700">Exiger un dépôt de garantie</span>
+                </label>
+
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label htmlFor="depositAmount" className="form-label">Montant du dépôt (€)</label>
+                    <input
+                      id="depositAmount"
+                      name="depositAmount"
+                      type="number"
+                      min="0"
+                      step="10"
+                      className="form-input"
+                      value={formData.depositAmount}
+                      onChange={handleInputChange}
+                      disabled={isSaving || !formData.requireDeposit}
+                    />
+                  </div>
+
+                  <div>
+                    <label htmlFor="cleaningFee" className="form-label">Frais de ménage (€)</label>
+                    <input
+                      id="cleaningFee"
+                      name="cleaningFee"
+                      type="number"
+                      min="0"
+                      step="5"
+                      className="form-input"
+                      value={formData.cleaningFee}
+                      onChange={handleInputChange}
+                      disabled={isSaving}
+                    />
+                  </div>
+                </div>
+              </section>
+
+              <section className="card space-y-6 lg:col-span-2">
+                <div className="flex items-center gap-3">
+                  <Key className="h-6 w-6 text-primary-600" />
+                  <h2 className="text-lg font-semibold text-gray-900">Accès</h2>
+                </div>
+
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div>
+                    <label htmlFor="accessCode" className="form-label">Code d&apos;accès</label>
+                    <input
+                      id="accessCode"
+                      name="accessCode"
+                      type="text"
+                      className="form-input"
+                      value={formData.accessCode}
+                      onChange={handleInputChange}
+                      disabled={isSaving}
+                      placeholder="Ex: 458920"
+                    />
+                  </div>
+
+                  <div className="flex items-end">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const newCode = Math.random().toString().slice(-6);
+                        setFormData((prev) => ({ ...prev, accessCode: newCode }));
+                      }}
+                      className="btn-secondary w-full"
+                      disabled={isSaving}
+                    >
+                      Générer un code aléatoire
+                    </button>
+                  </div>
+                </div>
+              </section>
+            </div>
+
+            {saveError && (
+              <div className="rounded-lg border border-danger-200 bg-danger-50 px-4 py-3 text-danger-700">
+                {saveError}
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                className="btn-primary inline-flex items-center"
+                disabled={isSaving}
+              >
+                <Save className="mr-2 h-4 w-4" />
+                {isSaving ? 'Enregistrement...' : 'Enregistrer les paramètres'}
+              </button>
+            </div>
+          </form>
+        ) : (
+          <div className="card">
+            <p className="text-gray-600">Propriété introuvable.</p>
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a single-property API GET endpoint and allow updating property settings
- create a property details page that loads data via the API with protected routing
- implement a property settings form page to manage operational parameters

## Testing
- npm run lint *(fails: existing react/no-unescaped-entities violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d14139e384832ea43f2861d4eb0ef4