### PR TITLE
Add placeholder dashboard sections for future modules

### DIFF
--- a/app/calendar/page.js
+++ b/app/calendar/page.js
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Calendar, CalendarClock } from 'lucide-react';
+
+import DashboardLayout from '@/components/DashboardLayout';
+
+export default function CalendarPage() {
+  const router = useRouter();
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token');
+
+    if (!token) {
+      router.replace('/auth/login');
+      return;
+    }
+
+    setIsCheckingAuth(false);
+  }, [router]);
+
+  if (isCheckingAuth) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <div className="loading-spinner"></div>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Calendrier</h1>
+            <p className="mt-1 text-gray-600">
+              Visualisez vos check-ins, check-outs et interventions planifiées au même endroit.
+            </p>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="flex items-start space-x-3">
+            <div className="rounded-full bg-primary-100 p-2">
+              <Calendar className="h-6 w-6 text-primary-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Planning interactif en préparation</h2>
+              <p className="mt-2 text-gray-600">
+                Vous pourrez bientôt synchroniser vos réservations, suivre vos équipes terrain et automatiser les
+                rappels liés à vos états des lieux.
+              </p>
+              <p className="mt-2 text-sm text-gray-500">
+                Les intégrations iCal et les connexions avec vos OTA seront ajoutées dans une prochaine mise à jour.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="card bg-gray-900 text-white">
+          <div className="flex items-start space-x-3">
+            <CalendarClock className="h-6 w-6 flex-shrink-0" />
+            <div>
+              <h3 className="font-semibold">Restez informé</h3>
+              <p className="mt-1 text-sm text-gray-100">
+                Activez les notifications pour être alerté dès que le planning sera disponible et profiter des tests
+                bêta.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/deposits/page.js
+++ b/app/deposits/page.js
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { CreditCard, ShieldCheck } from 'lucide-react';
+
+import DashboardLayout from '@/components/DashboardLayout';
+
+export default function DepositsPage() {
+  const router = useRouter();
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token');
+
+    if (!token) {
+      router.replace('/auth/login');
+      return;
+    }
+
+    setIsCheckingAuth(false);
+  }, [router]);
+
+  if (isCheckingAuth) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <div className="loading-spinner"></div>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Cautions</h1>
+            <p className="mt-1 text-gray-600">
+              Suivez vos dépôts de garantie et préparez vos futurs remboursements.
+            </p>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="flex items-start space-x-3">
+            <div className="rounded-full bg-primary-100 p-2">
+              <CreditCard className="h-6 w-6 text-primary-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Gestion des cautions à venir</h2>
+              <p className="mt-2 text-gray-600">
+                Ce tableau de bord vous permettra bientôt de suivre les paiements, réclamations et remboursements
+                liés aux cautions de vos locations.
+              </p>
+              <p className="mt-2 text-sm text-gray-500">
+                Les intégrations Stripe et les rappels automatiques sont en cours de finalisation.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="card bg-primary-50 border-primary-100 text-primary-700">
+          <div className="flex items-start space-x-3">
+            <ShieldCheck className="h-6 w-6 flex-shrink-0" />
+            <div>
+              <h3 className="font-semibold">Sécurisez vos cautions avec Checkinly</h3>
+              <p className="mt-1 text-sm">
+                Bientôt, vous pourrez déclencher des paiements sécurisés, automatiser les relances et suivre les
+                litiges directement depuis cette interface.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/guests/new/page.js
+++ b/app/guests/new/page.js
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { UserPlus } from 'lucide-react';
+
+import DashboardLayout from '@/components/DashboardLayout';
+
+export default function NewGuestPage() {
+  const router = useRouter();
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token');
+
+    if (!token) {
+      router.replace('/auth/login');
+      return;
+    }
+
+    setIsCheckingAuth(false);
+  }, [router]);
+
+  if (isCheckingAuth) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <div className="loading-spinner"></div>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Ajouter un invité</h1>
+            <p className="mt-1 text-gray-600">
+              Cette page vous permettra bientôt de créer un nouveau profil voyageur et de préparer son check-in.
+            </p>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="flex items-start space-x-3">
+            <div className="rounded-full bg-primary-100 p-2">
+              <UserPlus className="h-6 w-6 text-primary-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Formulaire en cours de développement</h2>
+              <p className="mt-2 text-gray-600">
+                Nous travaillons sur un formulaire complet pour collecter les informations de vos invités, générer
+                des documents et automatiser la communication avant leur arrivée.
+              </p>
+              <button
+                onClick={() => router.push('/guests')}
+                className="mt-4 btn-secondary"
+              >
+                Retour à la liste des invités
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/guests/page.js
+++ b/app/guests/page.js
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Users, UserPlus } from 'lucide-react';
+
+import DashboardLayout from '@/components/DashboardLayout';
+
+export default function GuestsPage() {
+  const router = useRouter();
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token');
+
+    if (!token) {
+      router.replace('/auth/login');
+      return;
+    }
+
+    setIsCheckingAuth(false);
+  }, [router]);
+
+  if (isCheckingAuth) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <div className="loading-spinner"></div>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Invités</h1>
+            <p className="mt-1 text-gray-600">
+              Centralisez le suivi de vos voyageurs et préparez vos futures intégrations.
+            </p>
+          </div>
+          <button
+            onClick={() => router.push('/guests/new')}
+            className="mt-4 sm:mt-0 btn-primary flex items-center"
+          >
+            <UserPlus className="h-5 w-5 mr-2" />
+            Nouvel invité
+          </button>
+        </div>
+
+        <div className="card">
+          <div className="flex items-start space-x-3">
+            <div className="rounded-full bg-primary-100 p-2">
+              <Users className="h-6 w-6 text-primary-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">En construction</h2>
+              <p className="mt-2 text-gray-600">
+                Le module de gestion des invités sera bientôt disponible. Vous pourrez y inviter vos voyageurs,
+                suivre leur statut et préparer leurs check-ins.
+              </p>
+              <p className="mt-2 text-sm text-gray-500">
+                En attendant, continuez d&apos;utiliser vos processus actuels. Nous vous informerons dès que cette
+                fonctionnalité sera prête.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/settings/page.js
+++ b/app/settings/page.js
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Settings, Shield, Bell, Users } from 'lucide-react';
+
+import DashboardLayout from '@/components/DashboardLayout';
+
+export default function SettingsPage() {
+  const router = useRouter();
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    const token = localStorage.getItem('auth-token');
+
+    if (!token) {
+      router.replace('/auth/login');
+      return;
+    }
+
+    setIsCheckingAuth(false);
+  }, [router]);
+
+  if (isCheckingAuth) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <div className="loading-spinner"></div>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Paramètres</h1>
+            <p className="mt-1 text-gray-600">
+              Configurez votre compte, votre équipe et vos préférences d&apos;application.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="card">
+            <div className="flex items-start space-x-3">
+              <div className="rounded-full bg-primary-100 p-2">
+                <Shield className="h-6 w-6 text-primary-600" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Sécurité</h2>
+                <p className="mt-2 text-gray-600">
+                  Gérez l&apos;accès à votre compte, configurez la double authentification et contrôlez les sessions
+                  actives.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="flex items-start space-x-3">
+              <div className="rounded-full bg-primary-100 p-2">
+                <Bell className="h-6 w-6 text-primary-600" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Notifications</h2>
+                <p className="mt-2 text-gray-600">
+                  Personnalisez les alertes email et push pour suivre les événements importants de vos locations.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="flex items-start space-x-3">
+              <div className="rounded-full bg-primary-100 p-2">
+                <Users className="h-6 w-6 text-primary-600" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Équipe</h2>
+                <p className="mt-2 text-gray-600">
+                  Invitez des collaborateurs, attribuez des rôles et gérez leurs permissions.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="flex items-start space-x-3">
+              <div className="rounded-full bg-primary-100 p-2">
+                <Settings className="h-6 w-6 text-primary-600" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">Personnalisation</h2>
+                <p className="mt-2 text-gray-600">
+                  Configurez vos modèles d&apos;emails, vos documents PDF et vos intégrations.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="card bg-primary-50 border-primary-100 text-primary-700">
+          <h3 className="font-semibold">Bientôt disponible</h3>
+          <p className="mt-2 text-sm">
+            Nous mettons la touche finale à cette section pour vous offrir un contrôle total sur votre compte et vos
+            automatisations.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add authenticated placeholder screens for guests, guest creation, deposits, calendar, and settings modules
- keep navigation and quick actions intact by routing to the new stub pages
- describe upcoming functionality so users understand the areas are under construction

## Testing
- npm run lint *(fails: pre-existing react/no-unescaped-entities warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d143511c00832e803e7d50c11d6a0f