### PR TITLE
Fix dashboard auth token key

### DIFF
--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -66,7 +66,7 @@ export default function DashboardPage() {
     }
 
     const token =
-      typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
+      typeof window !== 'undefined' ? localStorage.getItem('auth-token') : null;
 
     if (!token) {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- ensure the dashboard reads the same auth token key stored during login

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d14a5f5db0832e8e2a67d8fb698d6f