### PR TITLE
feat: add dashboard property management

### DIFF
--- a/app/api/properties/utils.js
+++ b/app/api/properties/utils.js
@@ -9,7 +9,11 @@ export function validateAndNormalizePropertyPayload(data) {
     maxGuests,
     bedrooms,
     bathrooms,
-    amenities
+    amenities,
+    airbnbUrl,
+    bookingUrl,
+    profilePhoto,
+    descriptionPhotos
   } = data || {};
 
   if (!name || !name.trim() || !address || !address.trim() || !type || maxGuests === undefined || maxGuests === null) {
@@ -52,6 +56,91 @@ export function validateAndNormalizePropertyPayload(data) {
     };
   }
 
+  const normalizeUrl = (value) => {
+    if (!value || typeof value !== 'string') {
+      return '';
+    }
+
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return '';
+    }
+
+    try {
+      const url = new URL(trimmed);
+      if (!url.protocol.startsWith('http')) {
+        throw new Error('Invalid protocol');
+      }
+      return trimmed;
+    } catch (error) {
+      throw new Error('Invalid URL');
+    }
+  };
+
+  let normalizedAirbnbUrl = '';
+  let normalizedBookingUrl = '';
+  let normalizedProfilePhoto = '';
+
+  try {
+    normalizedAirbnbUrl = normalizeUrl(airbnbUrl);
+  } catch (error) {
+    return {
+      errorResponse: NextResponse.json(
+        { message: 'Lien Airbnb invalide' },
+        { status: 400 }
+      )
+    };
+  }
+
+  try {
+    normalizedBookingUrl = normalizeUrl(bookingUrl);
+  } catch (error) {
+    return {
+      errorResponse: NextResponse.json(
+        { message: 'Lien Booking invalide' },
+        { status: 400 }
+      )
+    };
+  }
+
+  try {
+    normalizedProfilePhoto = normalizeUrl(profilePhoto);
+  } catch (error) {
+    return {
+      errorResponse: NextResponse.json(
+        { message: 'URL de photo de profil invalide' },
+        { status: 400 }
+      )
+    };
+  }
+
+  let normalizedDescriptionPhotos = [];
+
+  if (descriptionPhotos !== undefined) {
+    if (!Array.isArray(descriptionPhotos)) {
+      return {
+        errorResponse: NextResponse.json(
+          { message: 'Les photos de description doivent être une liste' },
+          { status: 400 }
+        )
+      };
+    }
+
+    try {
+      normalizedDescriptionPhotos = descriptionPhotos
+        .map((photo) => normalizeUrl(photo))
+        .filter(Boolean);
+    } catch (error) {
+      return {
+        errorResponse: NextResponse.json(
+          { message: 'Une ou plusieurs URLs de photos de description sont invalides' },
+          { status: 400 }
+        )
+      };
+    }
+  }
+
   return {
     normalizedData: {
       name: name.trim(),
@@ -61,7 +150,11 @@ export function validateAndNormalizePropertyPayload(data) {
       maxGuests: maxGuestsValue,
       bedrooms: bedroomsValue ?? 1,
       bathrooms: bathroomsValue ?? 1,
-      amenities: Array.isArray(amenities) ? amenities : []
+      amenities: Array.isArray(amenities) ? amenities : [],
+      airbnbUrl: normalizedAirbnbUrl,
+      bookingUrl: normalizedBookingUrl,
+      profilePhoto: normalizedProfilePhoto,
+      descriptionPhotos: normalizedDescriptionPhotos
     }
   };
 }

--- a/app/dashboard/properties/page.js
+++ b/app/dashboard/properties/page.js
@@ -1,0 +1,264 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { Home, Plus, MapPin, Users, BarChart3, Trash2 } from 'lucide-react';
+import DashboardLayout from '@/components/DashboardLayout';
+import PropertyCard from '@/components/PropertyCard';
+import PropertyModal from '@/components/PropertyModal';
+
+const FILTERS = [
+  { key: 'all', label: 'Toutes' },
+  { key: 'active', label: 'Actives' },
+  { key: 'inactive', label: 'Inactives' }
+];
+
+export default function DashboardPropertiesPage() {
+  const [properties, setProperties] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [selectedProperty, setSelectedProperty] = useState(null);
+  const [filter, setFilter] = useState('all');
+  const [error, setError] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetchProperties();
+  }, []);
+
+  const fetchProperties = async () => {
+    try {
+      setIsLoading(true);
+      setError('');
+      const token = localStorage.getItem('auth-token');
+      const response = await fetch('/api/properties', {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error('Impossible de récupérer les propriétés');
+      }
+
+      const data = await response.json();
+      setProperties(data);
+    } catch (err) {
+      console.error('Error fetching properties:', err);
+      setError(err.message || 'Erreur inattendue lors du chargement des propriétés');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCreateProperty = () => {
+    setSelectedProperty(null);
+    setShowModal(true);
+  };
+
+  const handleEditProperty = (property) => {
+    setSelectedProperty(property);
+    setShowModal(true);
+  };
+
+  const handlePropertySaved = async () => {
+    await fetchProperties();
+    setShowModal(false);
+  };
+
+  const handleDeleteProperty = async (property) => {
+    if (!property || isDeleting) {
+      return;
+    }
+
+    const shouldDelete = window.confirm(
+      `Supprimer la propriété "${property.name}" ? Cette action est irréversible.`
+    );
+
+    if (!shouldDelete) {
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      setError('');
+      const token = localStorage.getItem('auth-token');
+      const response = await fetch(`/api/properties/${property.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.message || 'Erreur lors de la suppression');
+      }
+
+      await fetchProperties();
+    } catch (err) {
+      console.error('Error deleting property:', err);
+      setError(err.message || 'Erreur inattendue lors de la suppression de la propriété');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const filteredProperties = useMemo(() => {
+    return properties.filter((property) => {
+      if (filter === 'all') return true;
+      return property.status === filter;
+    });
+  }, [properties, filter]);
+
+  const stats = useMemo(() => {
+    const total = properties.length;
+    const active = properties.filter((property) => property.status === 'active').length;
+    const inactive = properties.filter((property) => property.status === 'inactive').length;
+    const totalCapacity = properties.reduce(
+      (acc, property) => acc + (property.maxGuests || 0),
+      0
+    );
+
+    return {
+      total,
+      active,
+      inactive,
+      totalCapacity
+    };
+  }, [properties]);
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <div className="loading-spinner" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Propriétés</h1>
+            <p className="mt-1 text-gray-600">
+              Centralisez vos logements, leurs liens de réservation et leurs photos.
+            </p>
+          </div>
+          <button onClick={handleCreateProperty} className="btn-primary inline-flex items-center">
+            <Plus className="h-5 w-5 mr-2" />
+            Ajouter une propriété
+          </button>
+        </div>
+
+        {error && (
+          <div className="bg-danger-50 border border-danger-200 text-danger-700 rounded-lg p-4 text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <div className="card text-center">
+            <div className="w-12 h-12 mx-auto mb-3 bg-primary-100 rounded-full flex items-center justify-center">
+              <Home className="h-6 w-6 text-primary-600" />
+            </div>
+            <div className="text-2xl font-bold text-gray-900">{stats.total}</div>
+            <div className="text-sm text-gray-600">Total propriétés</div>
+          </div>
+
+          <div className="card text-center">
+            <div className="w-12 h-12 mx-auto mb-3 bg-success-100 rounded-full flex items-center justify-center">
+              <BarChart3 className="h-6 w-6 text-success-600" />
+            </div>
+            <div className="text-2xl font-bold text-gray-900">{stats.active}</div>
+            <div className="text-sm text-gray-600">Actives</div>
+          </div>
+
+          <div className="card text-center">
+            <div className="w-12 h-12 mx-auto mb-3 bg-warning-100 rounded-full flex items-center justify-center">
+              <Trash2 className="h-6 w-6 text-warning-600" />
+            </div>
+            <div className="text-2xl font-bold text-gray-900">{stats.inactive}</div>
+            <div className="text-sm text-gray-600">Inactives</div>
+          </div>
+
+          <div className="card text-center">
+            <div className="w-12 h-12 mx-auto mb-3 bg-primary-100 rounded-full flex items-center justify-center">
+              <Users className="h-6 w-6 text-primary-600" />
+            </div>
+            <div className="text-2xl font-bold text-gray-900">{stats.totalCapacity}</div>
+            <div className="text-sm text-gray-600">Capacité totale (invités)</div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2 bg-gray-100 rounded-lg p-1">
+          {FILTERS.map((item) => (
+            <button
+              key={item.key}
+              onClick={() => setFilter(item.key)}
+              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                filter === item.key
+                  ? 'bg-white text-primary-700 shadow-sm'
+                  : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        {filteredProperties.length === 0 ? (
+          <div className="card text-center py-12">
+            <MapPin className="h-16 w-16 mx-auto mb-4 text-gray-300" />
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              {filter === 'all'
+                ? 'Aucune propriété enregistrée'
+                : `Aucune propriété ${filter === 'active' ? 'active' : 'inactive'}`}
+            </h3>
+            <p className="text-gray-600 mb-6">
+              {filter === 'all'
+                ? 'Ajoutez votre premier logement pour commencer la gestion.'
+                : 'Aucune propriété ne correspond à ce filtre.'}
+            </p>
+            {filter === 'all' && (
+              <button onClick={handleCreateProperty} className="btn-primary inline-flex items-center">
+                <Plus className="h-5 w-5 mr-2" />
+                Ajouter une propriété
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+            {filteredProperties.map((property) => (
+              <PropertyCard
+                key={property.id}
+                property={property}
+                onEdit={handleEditProperty}
+                onView={(currentProperty) => router.push(`/properties/${currentProperty.id}`)}
+                onCalendar={(currentProperty) =>
+                  router.push(`/calendar?property=${currentProperty.id}`)
+                }
+                onSettings={(currentProperty) =>
+                  router.push(`/properties/${currentProperty.id}/settings`)
+                }
+                onDelete={handleDeleteProperty}
+              />
+            ))}
+          </div>
+        )}
+
+        {showModal && (
+          <PropertyModal
+            property={selectedProperty}
+            onClose={() => setShowModal(false)}
+            onSave={handlePropertySaved}
+          />
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/components/DashboardLayout.js
+++ b/components/DashboardLayout.js
@@ -3,11 +3,11 @@
 import { useState, useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
-import { 
-  Home, 
-  FileText, 
-  Users, 
-  CreditCard, 
+import {
+  Home,
+  FileText,
+  Users,
+  CreditCard,
   Calendar,
   Settings,
   LogOut,
@@ -17,7 +17,8 @@ import {
   Bell,
   User,
   ChevronDown,
-  BookOpen
+  BookOpen,
+  Building2
 } from 'lucide-react';
 
 export default function DashboardLayout({ children }) {
@@ -75,6 +76,7 @@ export default function DashboardLayout({ children }) {
 
   const navigation = [
     { name: 'Dashboard', href: '/dashboard', icon: Home },
+    { name: 'Propriétés', href: '/dashboard/properties', icon: Building2 },
     { name: 'Inventaires', href: '/inventory', icon: FileText },
     { name: 'Guests', href: '/guests', icon: Users },
     { name: 'Cautions', href: '/deposits', icon: CreditCard },
@@ -85,6 +87,7 @@ export default function DashboardLayout({ children }) {
 
   const mobileNavigation = [
     { name: 'Dashboard', href: '/dashboard', icon: Home },
+    { name: 'Propriétés', href: '/dashboard/properties', icon: Building2 },
     { name: 'Inventaires', href: '/inventory', icon: FileText },
     { name: 'Guests', href: '/guests', icon: Users },
     { name: 'Cautions', href: '/deposits', icon: CreditCard },

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -1,10 +1,10 @@
 'use client';
 
-import { 
-  Home, 
-  MapPin, 
-  Users, 
-  Bed, 
+import Image from 'next/image';
+import {
+  MapPin,
+  Users,
+  Bed,
   Bath,
   Settings,
   Eye,
@@ -12,11 +12,21 @@ import {
   Edit,
   MoreVertical,
   Star,
-  TrendingUp
+  TrendingUp,
+  Trash2,
+  Link2,
+  ImageIcon
 } from 'lucide-react';
 import { useState } from 'react';
 
-export default function PropertyCard({ property, onEdit, onView, onCalendar, onSettings }) {
+export default function PropertyCard({
+  property,
+  onEdit,
+  onView,
+  onCalendar,
+  onSettings,
+  onDelete
+}) {
   const [showDropdown, setShowDropdown] = useState(false);
 
   const getStatusColor = (status) => {
@@ -63,7 +73,7 @@ export default function PropertyCard({ property, onEdit, onView, onCalendar, onS
             <span className="truncate">{property.address}</span>
           </div>
         </div>
-        
+
         {/* Dropdown Menu */}
         <div className="relative">
           <button
@@ -120,11 +130,36 @@ export default function PropertyCard({ property, onEdit, onView, onCalendar, onS
                   <Settings className="h-4 w-4 mr-2" />
                   Paramètres
                 </button>
+                {onDelete && (
+                  <button
+                    onClick={() => {
+                      onDelete(property);
+                      setShowDropdown(false);
+                    }}
+                    className="w-full px-4 py-2 text-left text-sm text-danger-600 hover:bg-danger-50 flex items-center"
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Supprimer
+                  </button>
+                )}
               </div>
             </>
           )}
         </div>
       </div>
+
+      {property.profilePhoto && (
+        <div className="mb-4 overflow-hidden rounded-lg h-40 bg-gray-100 relative">
+          <Image
+            src={property.profilePhoto}
+            alt={`Photo de ${property.name}`}
+            fill
+            className="object-cover"
+            sizes="(min-width: 1280px) 320px, (min-width: 1024px) 280px, (min-width: 768px) 45vw, 90vw"
+            unoptimized
+          />
+        </div>
+      )}
 
       {/* Property Details */}
       <div className="grid grid-cols-3 gap-4 mb-4">
@@ -190,6 +225,60 @@ export default function PropertyCard({ property, onEdit, onView, onCalendar, onS
           Planning
         </button>
       </div>
+
+      {(property.airbnbUrl || property.bookingUrl) && (
+        <div className="mt-4 pt-4 border-t border-gray-100">
+          <div className="text-xs font-semibold text-gray-500 uppercase mb-2 flex items-center">
+            <Link2 className="h-4 w-4 mr-2" />
+            Référencement
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {property.airbnbUrl && (
+              <a
+                href={property.airbnbUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center px-3 py-1.5 text-sm rounded-full bg-primary-50 text-primary-700 hover:bg-primary-100 transition-colors"
+              >
+                Airbnb
+              </a>
+            )}
+            {property.bookingUrl && (
+              <a
+                href={property.bookingUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center px-3 py-1.5 text-sm rounded-full bg-primary-50 text-primary-700 hover:bg-primary-100 transition-colors"
+              >
+                Booking
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+
+      {property.descriptionPhotos?.length > 0 && (
+        <div className="mt-4 pt-4 border-t border-gray-100">
+          <div className="text-xs font-semibold text-gray-500 uppercase mb-2 flex items-center">
+            <ImageIcon className="h-4 w-4 mr-2" />
+            Photos descriptives
+          </div>
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {property.descriptionPhotos.map((photo, index) => (
+              <div key={photo} className="relative h-16 w-24 flex-shrink-0 overflow-hidden rounded-md bg-gray-100">
+                <Image
+                  src={photo}
+                  alt={`Photo ${index + 1} de ${property.name}`}
+                  fill
+                  className="object-cover"
+                  sizes="96px"
+                  unoptimized
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Description */}
       {property.description && (


### PR DESCRIPTION
## Summary
- add a dedicated dashboard properties page with filtering, CRUD actions, and delete confirmation
- extend the property modal and cards to capture links, profile photo, and descriptive photos
- validate new property fields on the API and expose the page in the dashboard navigation

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d152969d88832eb2cbeaad4dc239ee