### PR TITLE
Add mock super admin user for login API

### DIFF
--- a/app/api/auth/login/route.js
+++ b/app/api/auth/login/route.js
@@ -12,6 +12,15 @@ const users = [
     password: '$2a$10$jLSs2TRYBiH1rn42gXs7ie.rtt94Dszb.w4sF3NvmK/1suZRN.xdG', // demo123
     role: 'owner',
     createdAt: new Date().toISOString()
+  },
+  {
+    id: '2',
+    firstName: 'Super',
+    lastName: 'Admin',
+    email: 'superadmin@checkinly.com',
+    password: '$2a$10$mGh2Y1yHBfKSFY07dYWyAekI6O/RwpnPaelHqZeUEBbEvXsc1d9Ii', // super123
+    role: 'super_admin',
+    createdAt: new Date().toISOString()
   }
 ];
 


### PR DESCRIPTION
## Summary
- extend the mocked login users list with a super admin account
- assign the new user the super_admin role so the super admin dashboard can be accessed during demos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d345a98c832e8c7a6ffcabd9cb35