### PR TITLE
Add dashboard segment layout

### DIFF
--- a/app/dashboard/calendrier/page.js
+++ b/app/dashboard/calendrier/page.js
@@ -15,7 +15,6 @@ import {
   Mail,
 } from 'lucide-react';
 
-import DashboardLayout from '@/components/DashboardLayout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -561,16 +560,14 @@ export default function DashboardCalendarPage() {
 
   if (isCheckingAuth) {
     return (
-      <DashboardLayout>
-        <div className="flex h-64 items-center justify-center">
-          <div className="loading-spinner" />
-        </div>
-      </DashboardLayout>
+      <div className="flex h-64 items-center justify-center">
+        <div className="loading-spinner" />
+      </div>
     );
   }
 
   return (
-    <DashboardLayout>
+    <>
       <div className="space-y-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -716,6 +713,6 @@ export default function DashboardCalendarPage() {
           </DialogContent>
         </Dialog>
       </div>
-    </DashboardLayout>
+    </>
   );
 }

--- a/app/dashboard/guests/page.js
+++ b/app/dashboard/guests/page.js
@@ -20,7 +20,6 @@ import {
   X,
 } from 'lucide-react';
 
-import DashboardLayout from '@/components/DashboardLayout';
 import { Badge } from '@/components/ui/badge';
 import {
   Table,
@@ -308,7 +307,7 @@ export default function DashboardGuestsPage() {
   const stayLabel = (guest) => `${formatDate(guest.stayStart)} → ${formatDate(guest.stayEnd)}`;
 
   return (
-    <DashboardLayout>
+    <>
       <div className="space-y-6">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
@@ -753,6 +752,6 @@ export default function DashboardGuestsPage() {
           </div>
         </form>
       </ModalShell>
-    </DashboardLayout>
+    </>
   );
 }

--- a/app/dashboard/layout.js
+++ b/app/dashboard/layout.js
@@ -1,0 +1,7 @@
+'use client';
+
+import DashboardLayout from '@/components/DashboardLayout';
+
+export default function DashboardSegmentLayout({ children }) {
+  return <DashboardLayout>{children}</DashboardLayout>;
+}

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -17,7 +17,6 @@ import {
   QrCode,
   Download
 } from 'lucide-react';
-import DashboardLayout from '@/components/DashboardLayout';
 import WelcomeModal from '@/components/WelcomeModal';
 import StatsCard from '@/components/StatsCard';
 import RecentActivity from '@/components/RecentActivity';
@@ -175,16 +174,14 @@ export default function DashboardPage() {
 
   if (isLoading) {
     return (
-      <DashboardLayout>
-        <div className="flex items-center justify-center h-64">
-          <div className="loading-spinner"></div>
-        </div>
-      </DashboardLayout>
+      <div className="flex items-center justify-center h-64">
+        <div className="loading-spinner"></div>
+      </div>
     );
   }
 
   return (
-    <DashboardLayout>
+    <>
       <div className="space-y-6">
         {/* Welcome Message */}
         <div className="bg-gradient-to-r from-primary-600 to-primary-700 rounded-lg text-white p-6">
@@ -357,6 +354,6 @@ export default function DashboardPage() {
       {showWelcome && (
         <WelcomeModal onClose={() => setShowWelcome(false)} />
       )}
-    </DashboardLayout>
+    </>
   );
 }

--- a/app/dashboard/properties/page.js
+++ b/app/dashboard/properties/page.js
@@ -3,7 +3,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { Home, Plus, MapPin, Users, BarChart3, Trash2 } from 'lucide-react';
-import DashboardLayout from '@/components/DashboardLayout';
 import PropertyCard from '@/components/PropertyCard';
 import PropertyModal from '@/components/PropertyModal';
 
@@ -131,16 +130,14 @@ export default function DashboardPropertiesPage() {
 
   if (isLoading) {
     return (
-      <DashboardLayout>
-        <div className="flex items-center justify-center h-64">
-          <div className="loading-spinner" />
-        </div>
-      </DashboardLayout>
+      <div className="flex items-center justify-center h-64">
+        <div className="loading-spinner" />
+      </div>
     );
   }
 
   return (
-    <DashboardLayout>
+    <>
       <div className="space-y-6">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
@@ -259,6 +256,6 @@ export default function DashboardPropertiesPage() {
           />
         )}
       </div>
-    </DashboardLayout>
+    </>
   );
 }

--- a/app/dashboard/super-admin/page.js
+++ b/app/dashboard/super-admin/page.js
@@ -19,7 +19,6 @@ import {
   Users
 } from 'lucide-react';
 
-import DashboardLayout from '@/components/DashboardLayout';
 import StatsCard from '@/components/StatsCard';
 import { cn } from '@/lib/utils';
 
@@ -392,30 +391,25 @@ export default function SuperAdminDashboard() {
 
   if (!authState.checked) {
     return (
-      <DashboardLayout>
-        <div className="space-y-6">
-          <div className="card animate-pulse h-40" />
-          <div className="card animate-pulse h-40" />
-        </div>
-      </DashboardLayout>
+      <div className="space-y-6">
+        <div className="card animate-pulse h-40" />
+        <div className="card animate-pulse h-40" />
+      </div>
     );
   }
 
   if (!authState.authorized) {
     return (
-      <DashboardLayout>
-        <div className="card">
-          <div className="p-6">
-            <p className="text-gray-600">Redirection en cours…</p>
-          </div>
+      <div className="card">
+        <div className="p-6">
+          <p className="text-gray-600">Redirection en cours…</p>
         </div>
-      </DashboardLayout>
+      </div>
     );
   }
 
   return (
-    <DashboardLayout>
-      <div className="space-y-6">
+    <div className="space-y-6">
         <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">
             <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Pilotage global</h1>
@@ -774,6 +768,5 @@ export default function SuperAdminDashboard() {
           </div>
         </section>
       </div>
-    </DashboardLayout>
   );
 }


### PR DESCRIPTION
## Summary
- create a dedicated client layout for the dashboard segment that wraps children with `DashboardLayout`
- remove redundant `DashboardLayout` imports/usages from dashboard pages now covered by the segment layout
- keep loading states functional while simplifying page JSX wrappers for admin and super-admin dashboards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d25b502d00832e867c812ea931cda3