### PR TITLE
Integrate Cloudinary photo uploads for properties

### DIFF
--- a/app/api/upload/route.js
+++ b/app/api/upload/route.js
@@ -1,0 +1,150 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth';
+import {
+  buildThumbnailUrl,
+  ensureCloudinaryConfig,
+  getCloudinaryConfig,
+  signCloudinaryParams
+} from '@/lib/cloudinary';
+
+export const runtime = 'nodejs';
+
+async function uploadToCloudinary(file, folder) {
+  ensureCloudinaryConfig();
+  const config = getCloudinaryConfig();
+  const timestamp = Math.floor(Date.now() / 1000);
+  const paramsToSign = {
+    folder,
+    timestamp
+  };
+  const signature = signCloudinaryParams(paramsToSign);
+
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('folder', folder);
+  formData.append('timestamp', String(timestamp));
+  formData.append('api_key', config.apiKey);
+  formData.append('signature', signature);
+
+  const response = await fetch(`https://api.cloudinary.com/v1_1/${config.cloudName}/image/upload`, {
+    method: 'POST',
+    body: formData
+  });
+
+  if (!response.ok) {
+    let message = 'Cloudinary upload failed';
+    try {
+      const errorBody = await response.json();
+      message = errorBody?.error?.message || message;
+    } catch (parseError) {
+      // ignore parsing errors and use default message
+    }
+    throw new Error(message);
+  }
+
+  const result = await response.json();
+  const thumbnailUrl = buildThumbnailUrl(result.public_id, result.format);
+
+  return {
+    url: result.secure_url,
+    publicId: result.public_id,
+    format: result.format,
+    thumbnailUrl
+  };
+}
+
+async function deleteFromCloudinary(publicId) {
+  ensureCloudinaryConfig();
+  const config = getCloudinaryConfig();
+  const timestamp = Math.floor(Date.now() / 1000);
+  const paramsToSign = {
+    public_id: publicId,
+    timestamp
+  };
+  const signature = signCloudinaryParams(paramsToSign);
+
+  const formData = new FormData();
+  formData.append('public_id', publicId);
+  formData.append('timestamp', String(timestamp));
+  formData.append('api_key', config.apiKey);
+  formData.append('signature', signature);
+
+  const response = await fetch(`https://api.cloudinary.com/v1_1/${config.cloudName}/image/destroy`, {
+    method: 'POST',
+    body: formData
+  });
+
+  if (!response.ok) {
+    let message = 'Cloudinary deletion failed';
+    try {
+      const errorBody = await response.json();
+      message = errorBody?.error?.message || message;
+    } catch (parseError) {
+      // ignore parsing errors and use default message
+    }
+    throw new Error(message);
+  }
+
+  const result = await response.json();
+
+  if (result.result !== 'ok' && result.result !== 'not found') {
+    throw new Error(result.result || 'Cloudinary deletion failed');
+  }
+}
+
+export async function POST(request) {
+  try {
+    const user = await requireAuth(request);
+
+    const formData = await request.formData();
+    const file = formData.get('file');
+    const folderInput = formData.get('folder');
+
+    if (!file || typeof file === 'string') {
+      return NextResponse.json(
+        { message: 'Aucun fichier fourni' },
+        { status: 400 }
+      );
+    }
+
+    const folder = folderInput
+      ? `checkin/${user.id}/${String(folderInput)}`
+      : `checkin/${user.id}/properties`;
+
+    const uploadResult = await uploadToCloudinary(file, folder);
+
+    return NextResponse.json(uploadResult);
+  } catch (error) {
+    console.error('Cloudinary upload error:', error);
+    return NextResponse.json(
+      { message: error.message || 'Erreur lors du téléchargement de la photo' },
+      { status: error.message === 'Invalid token' || error.message === 'No token provided' ? 401 : 500 }
+    );
+  }
+}
+
+export async function DELETE(request) {
+  try {
+    await requireAuth(request);
+
+    const body = await request.json();
+    const { publicId } = body || {};
+
+    if (!publicId || typeof publicId !== 'string') {
+      return NextResponse.json(
+        { message: "Identifiant d'image manquant" },
+        { status: 400 }
+      );
+    }
+
+    await deleteFromCloudinary(publicId);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Cloudinary delete error:', error);
+    return NextResponse.json(
+      { message: error.message || "Erreur lors de la suppression de l'image" },
+      { status: error.message === 'Invalid token' || error.message === 'No token provided' ? 401 : 500 }
+    );
+  }
+}

--- a/components/PropertyCard.js
+++ b/components/PropertyCard.js
@@ -55,6 +55,41 @@ export default function PropertyCard({
     }
   };
 
+  const getPhotoUrl = (photo) => {
+    if (!photo) {
+      return '';
+    }
+
+    if (typeof photo === 'string') {
+      return photo;
+    }
+
+    if (typeof photo === 'object') {
+      return photo.url || '';
+    }
+
+    return '';
+  };
+
+  const getThumbnailUrl = (photo) => {
+    if (!photo) {
+      return '';
+    }
+
+    if (typeof photo === 'string') {
+      return photo;
+    }
+
+    if (typeof photo === 'object') {
+      return photo.thumbnailUrl || photo.url || '';
+    }
+
+    return '';
+  };
+
+  const profilePhotoUrl = getPhotoUrl(property.profilePhoto);
+  const profilePhotoThumbnail = getThumbnailUrl(property.profilePhoto);
+
   return (
     <div className="card hover-lift group relative">
       {/* Header */}
@@ -148,10 +183,10 @@ export default function PropertyCard({
         </div>
       </div>
 
-      {property.profilePhoto && (
+      {profilePhotoUrl && (
         <div className="mb-4 overflow-hidden rounded-lg h-40 bg-gray-100 relative">
           <Image
-            src={property.profilePhoto}
+            src={profilePhotoThumbnail}
             alt={`Photo de ${property.name}`}
             fill
             className="object-cover"
@@ -264,18 +299,31 @@ export default function PropertyCard({
             Photos descriptives
           </div>
           <div className="flex gap-2 overflow-x-auto pb-1">
-            {property.descriptionPhotos.map((photo, index) => (
-              <div key={photo} className="relative h-16 w-24 flex-shrink-0 overflow-hidden rounded-md bg-gray-100">
-                <Image
-                  src={photo}
-                  alt={`Photo ${index + 1} de ${property.name}`}
-                  fill
-                  className="object-cover"
-                  sizes="96px"
-                  unoptimized
-                />
-              </div>
-            ))}
+            {property.descriptionPhotos.map((photo, index) => {
+              const photoData =
+                typeof photo === 'string'
+                  ? { url: photo, thumbnailUrl: photo, publicId: photo }
+                  : photo;
+
+              if (!photoData?.url) {
+                return null;
+              }
+
+              const key = photoData.publicId || `${photoData.url}-${index}`;
+
+              return (
+                <div key={key} className="relative h-16 w-24 flex-shrink-0 overflow-hidden rounded-md bg-gray-100">
+                  <Image
+                    src={photoData.thumbnailUrl || photoData.url}
+                    alt={`Photo ${index + 1} de ${property.name}`}
+                    fill
+                    className="object-cover"
+                    sizes="96px"
+                    unoptimized
+                  />
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/lib/cloudinary.js
+++ b/lib/cloudinary.js
@@ -1,0 +1,40 @@
+import crypto from 'crypto';
+
+const cloudinaryConfig = {
+  cloudName: process.env.CLOUDINARY_CLOUD_NAME || '',
+  apiKey: process.env.CLOUDINARY_API_KEY || '',
+  apiSecret: process.env.CLOUDINARY_API_SECRET || ''
+};
+
+export function ensureCloudinaryConfig() {
+  if (!cloudinaryConfig.cloudName || !cloudinaryConfig.apiKey || !cloudinaryConfig.apiSecret) {
+    throw new Error('Cloudinary configuration is missing. Please set CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY and CLOUDINARY_API_SECRET.');
+  }
+}
+
+export function getCloudinaryConfig() {
+  return cloudinaryConfig;
+}
+
+export function signCloudinaryParams(params) {
+  const sortedEntries = Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .sort(([keyA], [keyB]) => (keyA < keyB ? -1 : keyA > keyB ? 1 : 0));
+
+  const stringToSign = sortedEntries
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+
+  return crypto
+    .createHash('sha1')
+    .update(`${stringToSign}${cloudinaryConfig.apiSecret}`)
+    .digest('hex');
+}
+
+export function buildThumbnailUrl(publicId, format, transformation = 'c_fill,g_auto,w_400,h_300') {
+  if (!publicId || !format) {
+    return '';
+  }
+
+  return `https://res.cloudinary.com/${cloudinaryConfig.cloudName}/image/upload/${transformation}/${publicId}.${format}`;
+}


### PR DESCRIPTION
## Summary
- add a Cloudinary helper module and upload API route that signs uploads and deletions per authenticated user
- update the property modal to upload, preview, and remove property photos through Cloudinary while persisting the returned metadata
- extend property validation and card rendering to support Cloudinary photo objects and thumbnails

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2716786e8832ea30b6763528b7961