### PR TITLE
Connect profile settings to MongoDB

### DIFF
--- a/app/api/profile/route.js
+++ b/app/api/profile/route.js
@@ -1,0 +1,152 @@
+import { NextResponse } from 'next/server';
+
+import { requireAuth } from '@/lib/auth';
+import { connectDB } from '@/lib/mongodb';
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function formatProfileResponse(user) {
+  const profile = user.profile || {};
+
+  return {
+    id: user.id,
+    firstName: user.firstName || '',
+    lastName: user.lastName || '',
+    email: user.email || '',
+    profile: {
+      phone: profile.phone || '',
+      jobTitle: profile.jobTitle || '',
+      bio: profile.bio || '',
+      photoUrl: profile.photoUrl || ''
+    }
+  };
+}
+
+export async function GET(request) {
+  try {
+    const authUser = await requireAuth(request);
+    const { db } = await connectDB();
+
+    const user = await db.collection('users').findOne(
+      { id: authUser.id },
+      {
+        projection: {
+          password: 0,
+          passwordHash: 0
+        }
+      }
+    );
+
+    if (!user) {
+      return NextResponse.json({ message: 'Utilisateur introuvable' }, { status: 404 });
+    }
+
+    return NextResponse.json(formatProfileResponse(user));
+  } catch (error) {
+    if (error.message === 'Invalid token' || error.message === 'No token provided') {
+      return NextResponse.json({ message: 'Non autorisé' }, { status: 401 });
+    }
+
+    console.error('Error while fetching profile:', error);
+    return NextResponse.json({ message: 'Impossible de récupérer le profil' }, { status: 500 });
+  }
+}
+
+export async function PUT(request) {
+  try {
+    const authUser = await requireAuth(request);
+    const { db } = await connectDB();
+
+    const payload = await request.json();
+    const firstName = payload.firstName?.trim();
+    const lastName = payload.lastName?.trim();
+    const email = payload.email?.trim().toLowerCase();
+
+    if (!firstName || !lastName || !email) {
+      return NextResponse.json(
+        { message: 'Prénom, nom et email sont requis' },
+        { status: 400 }
+      );
+    }
+
+    if (!emailRegex.test(email)) {
+      return NextResponse.json({ message: "Format d'email invalide" }, { status: 400 });
+    }
+
+    const existingUser = await db.collection('users').findOne({ id: authUser.id });
+
+    if (!existingUser) {
+      return NextResponse.json({ message: 'Utilisateur introuvable' }, { status: 404 });
+    }
+
+    if (existingUser.email !== email) {
+      const emailInUse = await db.collection('users').findOne({
+        email,
+        id: { $ne: authUser.id }
+      });
+
+      if (emailInUse) {
+        return NextResponse.json(
+          { message: 'Cette adresse email est déjà utilisée par un autre compte' },
+          { status: 409 }
+        );
+      }
+    }
+
+    const updatedProfile = {
+      ...((existingUser.profile && typeof existingUser.profile === 'object') ? existingUser.profile : {}),
+      phone: typeof payload.phone === 'string' ? payload.phone.trim() : existingUser.profile?.phone || '',
+      jobTitle:
+        typeof payload.jobTitle === 'string' ? payload.jobTitle.trim() : existingUser.profile?.jobTitle || '',
+      bio: typeof payload.bio === 'string' ? payload.bio.trim() : existingUser.profile?.bio || ''
+    };
+
+    const updateResult = await db.collection('users').findOneAndUpdate(
+      { id: authUser.id },
+      {
+        $set: {
+          firstName,
+          lastName,
+          email,
+          profile: updatedProfile,
+          updatedAt: new Date()
+        }
+      },
+      {
+        returnDocument: 'after',
+        projection: {
+          password: 0,
+          passwordHash: 0
+        }
+      }
+    );
+
+    const updatedUser = updateResult.value;
+
+    if (!updatedUser) {
+      return NextResponse.json({ message: 'Utilisateur introuvable' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      ...formatProfileResponse(updatedUser),
+      message: 'Profil mis à jour avec succès'
+    });
+  } catch (error) {
+    if (error.message === 'Invalid token' || error.message === 'No token provided') {
+      return NextResponse.json({ message: 'Non autorisé' }, { status: 401 });
+    }
+
+    if (error?.code === 11000) {
+      return NextResponse.json(
+        { message: 'Cette adresse email est déjà utilisée par un autre compte' },
+        { status: 409 }
+      );
+    }
+
+    console.error('Error while updating profile:', error);
+    return NextResponse.json(
+      { message: 'Une erreur est survenue lors de la mise à jour du profil' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/settings/profile/page.js
+++ b/app/settings/profile/page.js
@@ -2,30 +2,174 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Camera, Info, Mail, Phone, User } from 'lucide-react';
+import { AlertCircle, Camera, CheckCircle2, Info, Mail, Phone, User } from 'lucide-react';
 
 import DashboardLayout from '@/components/DashboardLayout';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 
+const defaultFormData = {
+  firstName: '',
+  lastName: '',
+  email: '',
+  phone: '',
+  jobTitle: '',
+  bio: ''
+};
+
 export default function ProfileSettingsPage() {
   const router = useRouter();
+  const [authToken, setAuthToken] = useState(null);
+  const [formData, setFormData] = useState(defaultFormData);
   const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
 
   useEffect(() => {
-    const token = localStorage.getItem('auth-token');
+    let isMounted = true;
 
-    if (!token) {
+    const initialize = async () => {
+      const storedToken = typeof window !== 'undefined' ? localStorage.getItem('auth-token') : null;
+
+      if (!storedToken) {
+        router.replace('/auth/login');
+        return;
+      }
+
+      if (!isMounted) {
+        return;
+      }
+
+      setAuthToken(storedToken);
+      setIsCheckingAuth(false);
+      setIsLoading(true);
+      setError('');
+      setSuccessMessage('');
+
+      try {
+        const response = await fetch('/api/profile', {
+          headers: {
+            Authorization: `Bearer ${storedToken}`
+          }
+        });
+
+        if (response.status === 401) {
+          localStorage.removeItem('auth-token');
+          router.replace('/auth/login');
+          return;
+        }
+
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          throw new Error(data.message || 'Impossible de charger le profil');
+        }
+
+        if (!isMounted) {
+          return;
+        }
+
+        setFormData({
+          firstName: data.firstName || '',
+          lastName: data.lastName || '',
+          email: data.email || '',
+          phone: data.profile?.phone || '',
+          jobTitle: data.profile?.jobTitle || '',
+          bio: data.profile?.bio || ''
+        });
+      } catch (fetchError) {
+        if (!isMounted) {
+          return;
+        }
+
+        console.error('Failed to load profile', fetchError);
+        setError(fetchError.message || 'Impossible de charger le profil');
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    initialize();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [router]);
+
+  const handleChange = (field) => (event) => {
+    const value = event.target.value;
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!authToken) {
       router.replace('/auth/login');
       return;
     }
 
-    setIsCheckingAuth(false);
-  }, [router]);
+    setIsSaving(true);
+    setError('');
+    setSuccessMessage('');
 
-  if (isCheckingAuth) {
+    try {
+      const response = await fetch('/api/profile', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`
+        },
+        body: JSON.stringify({
+          firstName: formData.firstName,
+          lastName: formData.lastName,
+          email: formData.email,
+          phone: formData.phone,
+          jobTitle: formData.jobTitle,
+          bio: formData.bio
+        })
+      });
+
+      if (response.status === 401) {
+        localStorage.removeItem('auth-token');
+        router.replace('/auth/login');
+        return;
+      }
+
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Une erreur est survenue lors de la mise à jour');
+      }
+
+      setFormData({
+        firstName: data.firstName || formData.firstName,
+        lastName: data.lastName || formData.lastName,
+        email: data.email || formData.email,
+        phone: data.profile?.phone ?? formData.phone,
+        jobTitle: data.profile?.jobTitle ?? formData.jobTitle,
+        bio: data.profile?.bio ?? formData.bio
+      });
+      setSuccessMessage(data.message || 'Profil mis à jour avec succès');
+    } catch (submitError) {
+      console.error('Failed to update profile', submitError);
+      setError(submitError.message || 'Une erreur est survenue lors de la mise à jour');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isCheckingAuth || (isLoading && !error)) {
     return (
       <DashboardLayout>
         <div className="flex items-center justify-center h-64">
@@ -51,6 +195,25 @@ export default function ProfileSettingsPage() {
           </Button>
         </div>
 
+        {(error || successMessage) && (
+          <div className="space-y-4">
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-5 w-5" />
+                <AlertTitle>Une erreur est survenue</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            {successMessage && (
+              <Alert className="border-success-200 bg-success-50 text-success-700">
+                <CheckCircle2 className="h-5 w-5" />
+                <AlertTitle>Mise à jour réussie</AlertTitle>
+                <AlertDescription>{successMessage}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+        )}
+
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 card space-y-6">
             <div className="space-y-2">
@@ -60,46 +223,88 @@ export default function ProfileSettingsPage() {
               </p>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="first-name">Prénom</Label>
-                <Input id="first-name" placeholder="Alexandre" defaultValue="Alexandre" />
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="first-name">Prénom</Label>
+                  <Input
+                    id="first-name"
+                    placeholder="Alexandre"
+                    value={formData.firstName}
+                    onChange={handleChange('firstName')}
+                    disabled={isSaving}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="last-name">Nom</Label>
+                  <Input
+                    id="last-name"
+                    placeholder="Martin"
+                    value={formData.lastName}
+                    onChange={handleChange('lastName')}
+                    disabled={isSaving}
+                    required
+                  />
+                </div>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="last-name">Nom</Label>
-                <Input id="last-name" placeholder="Martin" defaultValue="Martin" />
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="contact@monagence.com"
+                    value={formData.email}
+                    onChange={handleChange('email')}
+                    disabled={isSaving}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="phone">Téléphone</Label>
+                  <Input
+                    id="phone"
+                    type="tel"
+                    placeholder="06 12 34 56 78"
+                    value={formData.phone}
+                    onChange={handleChange('phone')}
+                    disabled={isSaving}
+                  />
+                </div>
               </div>
-            </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label htmlFor="email">Email</Label>
-                <Input id="email" type="email" placeholder="contact@monagence.com" defaultValue="contact@monagence.com" />
+                <Label htmlFor="role">Rôle</Label>
+                <Input
+                  id="role"
+                  placeholder="Fondateur"
+                  value={formData.jobTitle}
+                  onChange={handleChange('jobTitle')}
+                  disabled={isSaving}
+                />
               </div>
+
               <div className="space-y-2">
-                <Label htmlFor="phone">Téléphone</Label>
-                <Input id="phone" type="tel" placeholder="06 12 34 56 78" defaultValue="06 12 34 56 78" />
+                <Label htmlFor="bio">Biographie</Label>
+                <Textarea
+                  id="bio"
+                  rows={4}
+                  placeholder="Décrivez votre expertise, votre approche et vos services pour instaurer la confiance."
+                  value={formData.bio}
+                  onChange={handleChange('bio')}
+                  disabled={isSaving}
+                />
               </div>
-            </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="role">Rôle</Label>
-              <Input id="role" placeholder="Fondateur" defaultValue="Fondateur" />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="bio">Biographie</Label>
-              <Textarea
-                id="bio"
-                rows={4}
-                placeholder="Décrivez votre expertise, votre approche et vos services pour instaurer la confiance."
-                defaultValue="Expert en conciergerie courte durée depuis 2018, je vous accompagne de A à Z pour optimiser vos revenus locatifs."
-              />
-            </div>
-
-            <div className="flex justify-end">
-              <Button>Enregistrer les modifications</Button>
-            </div>
+              <div className="flex justify-end">
+                <Button type="submit" disabled={isSaving} className="flex items-center">
+                  {isSaving && <div className="loading-spinner mr-2 h-5 w-5 border-b-2 border-white" />}
+                  Enregistrer les modifications
+                </Button>
+              </div>
+            </form>
           </div>
 
           <div className="card space-y-6">
@@ -115,7 +320,10 @@ export default function ProfileSettingsPage() {
                 <User className="mt-1 h-5 w-5 text-primary-600" />
                 <div>
                   <p className="font-medium text-gray-900">Nom affiché</p>
-                  <p className="text-sm text-gray-600">Alexandre Martin</p>
+                  <p className="text-sm text-gray-600">
+                    {[formData.firstName, formData.lastName].filter(Boolean).join(' ') || 'Non renseigné'}
+                  </p>
+                  <p className="text-sm text-gray-500 mt-1">{formData.jobTitle || 'Rôle non renseigné'}</p>
                 </div>
               </div>
 
@@ -123,7 +331,7 @@ export default function ProfileSettingsPage() {
                 <Mail className="mt-1 h-5 w-5 text-primary-600" />
                 <div>
                   <p className="font-medium text-gray-900">Email</p>
-                  <p className="text-sm text-gray-600">contact@monagence.com</p>
+                  <p className="text-sm text-gray-600">{formData.email || 'Non renseigné'}</p>
                 </div>
               </div>
 
@@ -131,7 +339,7 @@ export default function ProfileSettingsPage() {
                 <Phone className="mt-1 h-5 w-5 text-primary-600" />
                 <div>
                   <p className="font-medium text-gray-900">Téléphone</p>
-                  <p className="text-sm text-gray-600">06 12 34 56 78</p>
+                  <p className="text-sm text-gray-600">{formData.phone || 'Non renseigné'}</p>
                 </div>
               </div>
 
@@ -139,9 +347,7 @@ export default function ProfileSettingsPage() {
                 <Info className="mt-1 h-5 w-5 text-primary-600" />
                 <div>
                   <p className="font-medium text-gray-900">Présentation</p>
-                  <p className="text-sm text-gray-600">
-                    Expert en conciergerie, disponible 7j/7 pour accompagner vos voyageurs et maximiser la rentabilité de vos biens.
-                  </p>
+                  <p className="text-sm text-gray-600">{formData.bio || 'Non renseignée'}</p>
                 </div>
               </div>
             </div>

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -20,6 +20,15 @@ const notificationsSchema = z.object({
   sms: z.boolean()
 });
 
+const profileSchema = z
+  .object({
+    phone: z.string().trim().max(50).optional(),
+    jobTitle: z.string().trim().max(120).optional(),
+    bio: z.string().trim().max(2000).optional(),
+    photoUrl: z.string().trim().url().optional()
+  })
+  .partial();
+
 const settingsSchema = z.object({
   language: z.string().default('fr'),
   timezone: z.string().default('Europe/Paris'),
@@ -54,6 +63,7 @@ export const UserSchema = z.object({
   permissions: permissionsSchema,
   subscription: subscriptionSchema,
   settings: settingsSchema,
+  profile: profileSchema.optional(),
   stripeCustomerId: z.string().nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
@@ -106,12 +116,15 @@ export function buildUserDocument({
   createdAt,
   updatedAt,
   lastLoginAt,
-  metadata
+  metadata,
+  profile
 }) {
   const now = new Date();
   const trialEnds = subscription?.trialEnds
     ? new Date(subscription.trialEnds)
     : new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+  const sanitizedProfile = profile ? profileSchema.parse(profile) : undefined;
 
   const parsed = UserSchema.parse({
     id,
@@ -141,7 +154,8 @@ export function buildUserDocument({
     createdAt: createdAt ? new Date(createdAt) : now,
     updatedAt: updatedAt ? new Date(updatedAt) : now,
     lastLoginAt: lastLoginAt ? new Date(lastLoginAt) : undefined,
-    metadata: metadata || undefined
+    metadata: metadata || undefined,
+    profile: sanitizedProfile
   });
 
   return parsed;


### PR DESCRIPTION
## Summary
- create a profile API endpoint backed by MongoDB with read and update handlers
- extend the user model to support storing profile details
- wire the profile settings page to load and persist user information via the API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3bbcdc3c4832e8f4a071dc177d6f3