### PR TITLE
feat: add super admin provisioning and overview

### DIFF
--- a/app/api/auth/super-admin/route.js
+++ b/app/api/auth/super-admin/route.js
@@ -1,0 +1,131 @@
+import { NextResponse } from 'next/server';
+import bcrypt from 'bcryptjs';
+import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
+
+import { connectDB } from '@/lib/mongodb';
+import { buildSuperAdminUserDocument } from '@/lib/models/user';
+
+const SETUP_TOKEN = process.env.SUPERADMIN_SETUP_TOKEN;
+
+const payloadSchema = z.object({
+  firstName: z.string().trim().min(1),
+  lastName: z.string().trim().min(1),
+  email: z.string().trim().toLowerCase().email(),
+  password: z.string().min(8),
+  newsletter: z.boolean().optional().default(false)
+});
+
+function extractToken(request, payloadToken) {
+  if (!SETUP_TOKEN) {
+    throw new Error('SETUP_TOKEN_MISSING');
+  }
+
+  const providedToken =
+    (typeof payloadToken === 'string' && payloadToken) ||
+    request.headers.get('x-setup-token') ||
+    request.headers.get('X-Setup-Token') ||
+    request.headers.get('authorization');
+
+  if (!providedToken) {
+    return null;
+  }
+
+  if (providedToken.startsWith('Bearer ')) {
+    return providedToken.substring(7);
+  }
+
+  return providedToken;
+}
+
+export async function POST(request) {
+  try {
+    const rawPayload = await request.json();
+    const token = extractToken(request, rawPayload?.setupToken);
+
+    if (token !== SETUP_TOKEN) {
+      return NextResponse.json({ message: 'Accès interdit' }, { status: 403 });
+    }
+
+    const { setupToken, ...rest } = rawPayload || {};
+    const { firstName, lastName, email, password, newsletter } = payloadSchema.parse(rest);
+
+    const { db } = await connectDB();
+
+    const existingUser = await db.collection('users').findOne({ email });
+    if (existingUser) {
+      return NextResponse.json({ message: 'Un compte existe déjà pour cet email' }, { status: 409 });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 12);
+    const userId = uuidv4();
+
+    const userDocument = buildSuperAdminUserDocument({
+      id: userId,
+      firstName,
+      lastName,
+      email,
+      passwordHash: hashedPassword,
+      newsletter,
+      subscription: {
+        plan: 'enterprise',
+        status: 'active',
+        trialEnds: new Date()
+      }
+    });
+
+    await db.collection('users').insertOne(userDocument);
+
+    await db.collection('activity_logs').insertOne({
+      id: uuidv4(),
+      userId,
+      type: 'auth',
+      action: 'create_superadmin',
+      details: {
+        email,
+        firstName,
+        lastName
+      },
+      timestamp: new Date()
+    });
+
+    return NextResponse.json(
+      {
+        message: 'Compte super administrateur créé',
+        user: {
+          id: userDocument.id,
+          firstName: userDocument.firstName,
+          lastName: userDocument.lastName,
+          email: userDocument.email,
+          role: userDocument.role,
+          createdAt: userDocument.createdAt
+        }
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          message: 'Format des données invalide',
+          issues: error.issues
+        },
+        { status: 400 }
+      );
+    }
+
+    if (error.message === 'SETUP_TOKEN_MISSING') {
+      console.error('SUPERADMIN_SETUP_TOKEN manquant.');
+      return NextResponse.json(
+        { message: 'Configuration super administrateur invalide' },
+        { status: 500 }
+      );
+    }
+
+    console.error('Erreur création super administrateur:', error);
+    return NextResponse.json(
+      { message: 'Impossible de créer le compte super administrateur' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/super-admin/overview/route.js
+++ b/app/api/super-admin/overview/route.js
@@ -1,0 +1,238 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { requireAuth } from '@/lib/auth';
+import { connectDB } from '@/lib/mongodb';
+
+const COLLECTION_NAME = 'super_admin_overview';
+const DOCUMENT_ID = 'global-overview';
+
+const trendDirectionSchema = z.enum(['up', 'down']);
+
+const overviewSchema = z
+  .object({
+    lastUpdated: z.string().min(1).optional(),
+    metrics: z
+      .array(
+        z.object({
+          id: z.string().min(1),
+          title: z.string().min(1).optional(),
+          value: z.string().min(1),
+          trend: z.string().optional(),
+          trendDirection: trendDirectionSchema.optional(),
+          color: z.string().optional()
+        })
+      )
+      .optional(),
+    quickActions: z
+      .array(
+        z.object({
+          id: z.string().min(1),
+          title: z.string().min(1).optional(),
+          description: z.string().optional(),
+          tone: z.string().optional()
+        })
+      )
+      .optional(),
+    platformHealth: z
+      .object({
+        status: z.string().optional(),
+        uptime: z.string().optional(),
+        incidentsThisMonth: z.number().int().min(0).optional(),
+        responseTime: z.string().optional(),
+        deploymentFrequency: z.string().optional()
+      })
+      .optional(),
+    monthlyGrowth: z
+      .array(
+        z.object({
+          month: z.string().min(1),
+          revenue: z.number(),
+          owners: z.number().optional(),
+          properties: z.number().optional()
+        })
+      )
+      .optional(),
+    activity: z
+      .array(
+        z.object({
+          id: z.string().min(1),
+          title: z.string().min(1),
+          description: z.string().optional(),
+          date: z.string().optional(),
+          status: z.string().optional(),
+          type: z.string().optional()
+        })
+      )
+      .optional(),
+    support: z
+      .object({
+        openTickets: z.number().int().min(0).optional(),
+        criticalTickets: z.number().int().min(0).optional(),
+        satisfaction: z.number().min(0).max(100).optional(),
+        tickets: z
+          .array(
+            z.object({
+              id: z.string().min(1),
+              subject: z.string().min(1),
+              account: z.string().optional(),
+              priority: z.string().optional(),
+              status: z.string().optional(),
+              updated: z.string().optional()
+            })
+          )
+          .optional()
+      })
+      .optional(),
+    topOwners: z
+      .array(
+        z.object({
+          id: z.string().min(1),
+          name: z.string().min(1),
+          company: z.string().optional(),
+          properties: z.number().int().min(0).optional(),
+          occupancy: z.string().optional(),
+          revenue: z.string().optional(),
+          trend: z.string().optional()
+        })
+      )
+      .optional(),
+    roadmap: z
+      .array(
+        z.object({
+          id: z.string().min(1),
+          title: z.string().min(1),
+          quarter: z.string().optional(),
+          owner: z.string().optional(),
+          progress: z.number().int().min(0).max(100).optional(),
+          status: z.string().optional(),
+          description: z.string().optional()
+        })
+      )
+      .optional(),
+    expansion: z
+      .object({
+        markets: z
+          .array(
+            z.object({
+              id: z.string().min(1),
+              name: z.string().min(1),
+              status: z.string().optional(),
+              properties: z.number().int().min(0).optional()
+            })
+          )
+          .optional(),
+        pipeline: z
+          .array(
+            z.object({
+              id: z.string().min(1),
+              label: z.string().min(1),
+              value: z.number().int().min(0).optional()
+            })
+          )
+          .optional()
+      })
+      .optional()
+  })
+  .partial();
+
+async function ensureSuperAdmin(user) {
+  if (user.role !== 'superadmin') {
+    throw new Error('FORBIDDEN');
+  }
+}
+
+export async function GET(request) {
+  try {
+    const user = await requireAuth(request);
+    await ensureSuperAdmin(user);
+
+    const { db } = await connectDB();
+
+    const document = await db.collection(COLLECTION_NAME).findOne({ id: DOCUMENT_ID });
+
+    if (!document) {
+      return NextResponse.json({
+        lastUpdated: null
+      });
+    }
+
+    const { _id, id, ...payload } = document;
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    if (error.message === 'Invalid token' || error.message === 'No token provided') {
+      return NextResponse.json({ message: 'Authentification requise' }, { status: 401 });
+    }
+
+    if (error.message === 'FORBIDDEN') {
+      return NextResponse.json({ message: 'Accès refusé' }, { status: 403 });
+    }
+
+    console.error('Super admin overview GET error:', error);
+    return NextResponse.json({ message: 'Erreur lors de la récupération des données' }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const user = await requireAuth(request);
+    await ensureSuperAdmin(user);
+
+    const json = await request.json();
+    const parsed = overviewSchema.parse(json);
+
+    const { db } = await connectDB();
+
+    const update = {
+      id: DOCUMENT_ID,
+      ...parsed,
+      lastUpdated: parsed.lastUpdated || new Date().toISOString(),
+      updatedBy: {
+        id: user.id,
+        email: user.email
+      },
+      updatedAt: new Date()
+    };
+
+    await db.collection(COLLECTION_NAME).updateOne(
+      { id: DOCUMENT_ID },
+      { $set: update },
+      { upsert: true }
+    );
+
+    await db.collection('activity_logs').insertOne({
+      id: `${DOCUMENT_ID}-${Date.now()}`,
+      userId: user.id,
+      type: 'superadmin',
+      action: 'update_overview',
+      details: {
+        lastUpdated: update.lastUpdated
+      },
+      timestamp: new Date()
+    });
+
+    return NextResponse.json({ message: 'Vue mise à jour', ...update });
+  } catch (error) {
+    if (error.message === 'Invalid token' || error.message === 'No token provided') {
+      return NextResponse.json({ message: 'Authentification requise' }, { status: 401 });
+    }
+
+    if (error.message === 'FORBIDDEN') {
+      return NextResponse.json({ message: 'Accès refusé' }, { status: 403 });
+    }
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          message: 'Format des données invalide',
+          issues: error.issues
+        },
+        { status: 400 }
+      );
+    }
+
+    console.error('Super admin overview POST error:', error);
+    return NextResponse.json({ message: 'Erreur lors de la mise à jour des données' }, { status: 500 });
+  }
+}

--- a/components/DashboardLayout.js
+++ b/components/DashboardLayout.js
@@ -103,12 +103,12 @@ export default function DashboardLayout({ children }) {
   };
 
   const navigation =
-    user?.role === 'super_admin'
+      user?.role === 'superadmin'
       ? [baseNavigation[0], superAdminEntry, ...baseNavigation.slice(1)]
       : baseNavigation;
 
   const mobileNavigation =
-    user?.role === 'super_admin'
+      user?.role === 'superadmin'
       ? [baseMobileNavigation[0], superAdminEntry, ...baseMobileNavigation.slice(1)]
       : baseMobileNavigation;
 

--- a/components/StatsCard.js
+++ b/components/StatsCard.js
@@ -1,6 +1,13 @@
-import { TrendingUp, TrendingDown } from 'lucide-react';
+import { TrendingUp, TrendingDown, Users } from 'lucide-react';
 
-export default function StatsCard({ title, value, icon: Icon, color = 'primary', trend, trendDirection = 'up' }) {
+export default function StatsCard({
+  title,
+  value,
+  icon: Icon = Users,
+  color = 'primary',
+  trend,
+  trendDirection = 'up'
+}) {
   const colorClasses = {
     primary: 'bg-primary-50 text-primary-600',
     success: 'bg-success-50 text-success-600',


### PR DESCRIPTION
## Summary
- add an authenticated endpoint to provision super admin accounts behind a setup token
- expose a protected super admin overview API backed by MongoDB with validation and audit logs
- align client role checks and data merging to consume dynamic overview content safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4174aff68832eb30cc7a48358a75f