### PR TITLE
Handle missing value from property update and add tests

### DIFF
--- a/app/api/properties/[id]/route.js
+++ b/app/api/properties/[id]/route.js
@@ -177,6 +177,15 @@ export async function PUT(request, { params }) {
       { returnDocument: 'after' }
     );
 
+    const updatedProperty = updateResult?.value ?? updateResult;
+
+    if (!updatedProperty) {
+      return NextResponse.json(
+        { message: 'Propriété introuvable' },
+        { status: 404 }
+      );
+    }
+
     await db.collection('activity_logs').insertOne({
       id: uuidv4(),
       userId: user.id,
@@ -184,12 +193,12 @@ export async function PUT(request, { params }) {
       action: 'updated',
       details: {
         propertyId: id,
-        propertyName: updateResult.value.name
+        propertyName: updatedProperty.name ?? existingProperty.name ?? ''
       },
       timestamp: new Date()
     });
 
-    return NextResponse.json(updateResult.value);
+    return NextResponse.json(updatedProperty);
   } catch (error) {
     console.error('Property PUT error:', error);
     return NextResponse.json(

--- a/tests/api/properties-id-route.test.mjs
+++ b/tests/api/properties-id-route.test.mjs
@@ -1,0 +1,168 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+import { mocks } from '../mock-registry.mjs';
+
+const routeUrl = new URL('../../app/api/properties/[id]/route.js', import.meta.url);
+const { PUT } = await import(routeUrl);
+
+let jsonMock;
+let connectDBMock;
+let requireAuthMock;
+let validatePayloadMock;
+let uuidMock;
+
+test.beforeEach(() => {
+  jsonMock = mock.fn((body, init = {}) => ({
+    status: init?.status ?? 200,
+    body
+  }));
+  connectDBMock = mock.fn(async () => {
+    throw new Error('connectDB mock not configured');
+  });
+  requireAuthMock = mock.fn(async () => {
+    throw new Error('requireAuth mock not configured');
+  });
+  validatePayloadMock = mock.fn(() => {
+    throw new Error('validateAndNormalizePropertyPayload mock not configured');
+  });
+  uuidMock = mock.fn(() => 'test-uuid');
+
+  mocks.nextResponseJson = jsonMock;
+  mocks.connectDB = connectDBMock;
+  mocks.requireAuth = requireAuthMock;
+  mocks.validatePayload = validatePayloadMock;
+  mocks.uuidv4 = uuidMock;
+});
+
+test('returns updated property when driver omits value field', async () => {
+  requireAuthMock.mock.mockImplementation(async () => ({ id: 'user-1' }));
+  validatePayloadMock.mock.mockImplementation(() => ({
+    normalizedData: { name: 'Updated Name' }
+  }));
+
+  const existingProperty = { id: 'prop-1', userId: 'user-1', name: 'Old Name' };
+  const updatedProperty = { ...existingProperty, name: 'Updated Name' };
+
+  const findOneMock = mock.fn(async () => existingProperty);
+  const findOneAndUpdateMock = mock.fn(async () => updatedProperty);
+  const insertOneMock = mock.fn(async () => ({}));
+
+  connectDBMock.mock.mockImplementation(async () => ({
+    db: {
+      collection: (name) => {
+        if (name === 'properties') {
+          return {
+            findOne: findOneMock,
+            findOneAndUpdate: findOneAndUpdateMock
+          };
+        }
+        if (name === 'activity_logs') {
+          return {
+            insertOne: insertOneMock
+          };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      }
+    }
+  }));
+
+  const request = {
+    json: mock.fn(async () => ({ name: 'Updated Name' }))
+  };
+
+  const response = await PUT(request, { params: { id: 'prop-1' } });
+
+  assert.deepEqual(response, { status: 200, body: updatedProperty });
+  assert.equal(insertOneMock.mock.calls.length, 1);
+  const logArguments = insertOneMock.mock.calls[0].arguments[0];
+  assert.equal(logArguments.details.propertyName, 'Updated Name');
+});
+
+test('uses existing property name when updated document omits it', async () => {
+  requireAuthMock.mock.mockImplementation(async () => ({ id: 'user-1' }));
+  validatePayloadMock.mock.mockImplementation(() => ({
+    normalizedData: { name: 'Updated Name' }
+  }));
+
+  const existingProperty = { id: 'prop-1', userId: 'user-1', name: 'Existing Name' };
+  const updatedProperty = { id: 'prop-1', userId: 'user-1' };
+
+  const findOneMock = mock.fn(async () => existingProperty);
+  const findOneAndUpdateMock = mock.fn(async () => updatedProperty);
+  const insertOneMock = mock.fn(async () => ({}));
+
+  connectDBMock.mock.mockImplementation(async () => ({
+    db: {
+      collection: (name) => {
+        if (name === 'properties') {
+          return {
+            findOne: findOneMock,
+            findOneAndUpdate: findOneAndUpdateMock
+          };
+        }
+        if (name === 'activity_logs') {
+          return {
+            insertOne: insertOneMock
+          };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      }
+    }
+  }));
+
+  const request = {
+    json: mock.fn(async () => ({ name: 'Updated Name' }))
+  };
+
+  const response = await PUT(request, { params: { id: 'prop-1' } });
+
+  assert.deepEqual(response, { status: 200, body: updatedProperty });
+  assert.equal(insertOneMock.mock.calls.length, 1);
+  const logArguments = insertOneMock.mock.calls[0].arguments[0];
+  assert.equal(logArguments.details.propertyName, 'Existing Name');
+});
+
+test('returns 404 when no document is updated', async () => {
+  requireAuthMock.mock.mockImplementation(async () => ({ id: 'user-1' }));
+  validatePayloadMock.mock.mockImplementation(() => ({
+    normalizedData: { name: 'Updated Name' }
+  }));
+
+  const existingProperty = { id: 'prop-1', userId: 'user-1', name: 'Existing Name' };
+
+  const findOneMock = mock.fn(async () => existingProperty);
+  const findOneAndUpdateMock = mock.fn(async () => null);
+  const insertOneMock = mock.fn(async () => ({}));
+
+  connectDBMock.mock.mockImplementation(async () => ({
+    db: {
+      collection: (name) => {
+        if (name === 'properties') {
+          return {
+            findOne: findOneMock,
+            findOneAndUpdate: findOneAndUpdateMock
+          };
+        }
+        if (name === 'activity_logs') {
+          return {
+            insertOne: insertOneMock
+          };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      }
+    }
+  }));
+
+  const request = {
+    json: mock.fn(async () => ({ name: 'Updated Name' }))
+  };
+
+  const response = await PUT(request, { params: { id: 'prop-1' } });
+
+  assert.deepEqual(response, {
+    status: 404,
+    body: { message: 'Propriété introuvable' }
+  });
+  assert.equal(insertOneMock.mock.calls.length, 0);
+});

--- a/tests/mock-registry.mjs
+++ b/tests/mock-registry.mjs
@@ -1,0 +1,17 @@
+export const mocks = {
+  nextResponseJson: () => {
+    throw new Error('nextResponseJson mock not configured');
+  },
+  connectDB: async () => {
+    throw new Error('connectDB mock not configured');
+  },
+  requireAuth: async () => {
+    throw new Error('requireAuth mock not configured');
+  },
+  validatePayload: () => {
+    throw new Error('validateAndNormalizePropertyPayload mock not configured');
+  },
+  uuidv4: () => {
+    throw new Error('uuidv4 mock not configured');
+  }
+};

--- a/tests/stubs/lib-auth.mjs
+++ b/tests/stubs/lib-auth.mjs
@@ -1,0 +1,5 @@
+import { mocks } from '../mock-registry.mjs';
+
+export async function requireAuth(...args) {
+  return mocks.requireAuth(...args);
+}

--- a/tests/stubs/lib-mongodb.mjs
+++ b/tests/stubs/lib-mongodb.mjs
@@ -1,0 +1,5 @@
+import { mocks } from '../mock-registry.mjs';
+
+export async function connectDB(...args) {
+  return mocks.connectDB(...args);
+}

--- a/tests/stubs/next-server.mjs
+++ b/tests/stubs/next-server.mjs
@@ -1,0 +1,5 @@
+import { mocks } from '../mock-registry.mjs';
+
+export const NextResponse = {
+  json: (...args) => mocks.nextResponseJson(...args)
+};

--- a/tests/stubs/utils.mjs
+++ b/tests/stubs/utils.mjs
@@ -1,0 +1,5 @@
+import { mocks } from '../mock-registry.mjs';
+
+export function validateAndNormalizePropertyPayload(...args) {
+  return mocks.validatePayload(...args);
+}

--- a/tests/stubs/uuid.mjs
+++ b/tests/stubs/uuid.mjs
@@ -1,0 +1,3 @@
+import { mocks } from '../mock-registry.mjs';
+
+export const v4 = (...args) => mocks.uuidv4(...args);

--- a/tests/test-loader.mjs
+++ b/tests/test-loader.mjs
@@ -1,0 +1,55 @@
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const appDir = path.join(projectRoot, 'app');
+const libDir = path.join(projectRoot, 'lib');
+const stubsDir = path.join(projectRoot, 'tests', 'stubs');
+
+const stubMap = new Map([
+  ['next/server', pathToFileURL(path.join(stubsDir, 'next-server.mjs')).href],
+  ['@/lib/mongodb', pathToFileURL(path.join(stubsDir, 'lib-mongodb.mjs')).href],
+  ['@/lib/auth', pathToFileURL(path.join(stubsDir, 'lib-auth.mjs')).href],
+  ['uuid', pathToFileURL(path.join(stubsDir, 'uuid.mjs')).href]
+]);
+
+const routeFilePath = path.join(projectRoot, 'app', 'api', 'properties', '[id]', 'route.js');
+const utilsStubUrl = pathToFileURL(path.join(stubsDir, 'utils.mjs')).href;
+
+export async function resolve(specifier, context, nextResolve) {
+  if (stubMap.has(specifier)) {
+    return {
+      url: stubMap.get(specifier),
+      shortCircuit: true
+    };
+  }
+
+  if (specifier === '../utils' && typeof context.parentURL === 'string') {
+    const parentPath = fileURLToPath(context.parentURL);
+    if (parentPath === routeFilePath) {
+      return {
+        url: utilsStubUrl,
+        shortCircuit: true
+      };
+    }
+  }
+
+  if (specifier.startsWith('@/')) {
+    const targetUrl = pathToFileURL(path.join(projectRoot, specifier.slice(2))).href;
+    return nextResolve(targetUrl, context);
+  }
+
+  return nextResolve(specifier, context);
+}
+
+export async function load(url, context, nextLoad) {
+  if (url.startsWith('file://')) {
+    const filepath = fileURLToPath(url);
+    if (filepath.startsWith(appDir) || filepath.startsWith(libDir)) {
+      return nextLoad(url, { ...context, format: 'module' });
+    }
+  }
+
+  return nextLoad(url, context);
+}


### PR DESCRIPTION
## Summary
- normalise the result from `findOneAndUpdate` and guard against missing updates before logging or responding
- add a Node test harness with loader/stubbed modules to exercise the PUT `/api/properties/[id]` route behaviour

## Testing
- node --test --loader ./tests/test-loader.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d41e94174c832e9a4f553ae94d51f8