### PR TITLE
Fix preview URL memo in PropertyModal

### DIFF
--- a/components/PropertyModal.js
+++ b/components/PropertyModal.js
@@ -1072,9 +1072,6 @@ export default function PropertyModal({ property, onClose, onSave }) {
     return `${miniSiteBaseUrl}/${slug}`;
   }, [formData.onlinePresence.slug, miniSiteBaseUrl]);
 
-    return `https://checkinly.com/sejour/${slug}`;
-  }, [formData.onlinePresence.slug]);
-
 
   const handlePreviewClick = useCallback(() => {
     if (!previewUrl) {


### PR DESCRIPTION
## Summary
- remove the stray fallback return statement after the previewUrl memo to avoid double returns
- ensure the memo only derives the preview URL from the configured base URL and slug

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5beaad9c0832e8205f8de3f9cb074