### PR TITLE
Enable mini-site access via slug identifiers

### DIFF
--- a/app/properties/[id]/page.js
+++ b/app/properties/[id]/page.js
@@ -291,14 +291,15 @@ export default function PropertyDetailsPage() {
 
   useEffect(() => {
     if (property?.id && property?.userId && typeof window !== 'undefined') {
-      const originUrl = `${window.location.origin}/sejour/${property.userId}/${property.id}`;
-      setMiniSiteUrl(originUrl);
-
       const publicBaseUrl = (process.env.NEXT_PUBLIC_PUBLIC_SITE_URL || 'https://sejour.checkinly.fr').replace(
         /\/$/,
         ''
       );
-      const slug = property.onlinePresence?.slug || property.slug;
+      const slug = property.onlinePresence?.slug || property.slug || '';
+      const propertySegment = slug || property.id;
+      const originUrl = `${window.location.origin}/sejour/${property.userId}/${propertySegment}`;
+      setMiniSiteUrl(originUrl);
+
       if (slug) {
         setMiniSiteDisplayUrl(`${publicBaseUrl}/${slug}`);
       } else {

--- a/app/sejour/[propertyId]/page.js
+++ b/app/sejour/[propertyId]/page.js
@@ -1,0 +1,1 @@
+export { default, generateMetadata } from '../[userId]/[propertyId]/page';


### PR DESCRIPTION
## Summary
- allow the mini-site loader to resolve stays by slug as well as by internal id
- expose a slug-based `/sejour/[propertyId]` route that reuses the existing page implementation
- update the property dashboard to build mini-site URLs with the slug when available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5bfef84b0832e82c8ea67eca5084b