### PR TITLE
Fix property deletion error when document missing

### DIFF
--- a/app/api/properties/[id]/route.js
+++ b/app/api/properties/[id]/route.js
@@ -239,7 +239,7 @@ export async function DELETE(request, { params }) {
 
     const deleteResult = await db.collection('properties').findOneAndDelete({ id, userId: user.id });
 
-    if (!deleteResult.value) {
+    if (!deleteResult || !deleteResult.value) {
       return NextResponse.json(
         { message: 'Propriété introuvable' },
         { status: 404 }
@@ -253,7 +253,7 @@ export async function DELETE(request, { params }) {
       action: 'deleted',
       details: {
         propertyId: id,
-        propertyName: deleteResult.value.name
+        propertyName: deleteResult.value.name ?? deleteResult.value.general?.name ?? ''
       },
       timestamp: new Date()
     });


### PR DESCRIPTION
## Summary
- handle null results from `findOneAndDelete` when deleting properties
- fall back to additional fields when logging the deleted property name

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d64969c1ac832e87ca68ecd8140f23