### PR TITLE
Convert property header actions to icon buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,10 @@ body {
     @apply btn bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-primary-500;
   }
 
+  .btn-icon {
+    @apply inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+
   .btn-success {
     @apply btn bg-success-600 text-white hover:bg-success-700 focus:ring-success-500;
   }

--- a/app/properties/[id]/page.js
+++ b/app/properties/[id]/page.js
@@ -4,12 +4,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import {
   ArrowLeft,
+  Eye,
   Home,
   MapPin,
   Users,
   Bed,
   Bath,
-  Settings,
   Calendar,
   Key,
   Globe,
@@ -1332,22 +1332,31 @@ export default function PropertyDetailsPage() {
           </button>
 
           {property && (
-            <div className="flex items-center gap-3">
-              <button onClick={handleOpenCalendar} className="btn-secondary inline-flex items-center">
-                <Calendar className="mr-2 h-4 w-4" />
-                Calendrier
-              </button>
+            <div className="flex items-center gap-2">
               <button
                 onClick={handlePublish}
                 disabled={!miniSiteUrl}
-                className="btn-secondary inline-flex items-center border-primary-200 text-primary-700 hover:bg-primary-50"
+                className="btn-icon border-primary-200 text-primary-700 hover:bg-primary-50"
+                title="Voir le mini-site"
               >
-                <Globe className="mr-2 h-4 w-4" />
-                Publier
+                <Eye className="h-5 w-5" />
+                <span className="sr-only">Voir le mini-site</span>
               </button>
-              <button onClick={handleOpenSettings} className="btn-primary inline-flex items-center">
-                <Settings className="mr-2 h-4 w-4" />
-                Paramètres
+              <button
+                onClick={handleOpenCalendar}
+                className="btn-icon"
+                title="Ouvrir le calendrier"
+              >
+                <Calendar className="h-5 w-5" />
+                <span className="sr-only">Calendrier</span>
+              </button>
+              <button
+                onClick={handleOpenSettings}
+                className="btn-icon bg-primary-600 text-white border-primary-600 hover:bg-primary-700"
+                title="Modifier la propriété"
+              >
+                <Pencil className="h-5 w-5" />
+                <span className="sr-only">Modifier la propriété</span>
               </button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- add a reusable `btn-icon` utility style for circular icon-only controls
- replace the property header action buttons with eye, calendar, and pencil icons plus accessible labels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d667a38c04832e8bf0b702b0bf9d24