### PR TITLE
Fix dashboard route references after repo migration

### DIFF
--- a/app/api/inventories/[id]/duplicate/route.js
+++ b/app/api/inventories/[id]/duplicate/route.js
@@ -55,7 +55,7 @@ export async function POST(request, { params }) {
       id: newInventoryId,
       status: 'pending',
       progress: 0,
-      qrCodeUrl: `${baseUrl}/inventory/${newInventoryId}/fill`,
+      qrCodeUrl: `${baseUrl}/dashboard/inventory/${newInventoryId}/fill`,
       signature: null,
       photos: Array.isArray(existingPhotos) ? [...existingPhotos] : [],
       createdAt: now,

--- a/app/api/inventories/route.js
+++ b/app/api/inventories/route.js
@@ -146,7 +146,7 @@ export async function POST(request) {
       dueDate: dueDate ? new Date(dueDate) : null,
       rooms: rooms || [],
       progress: 0,
-      qrCodeUrl: `${process.env.NEXT_PUBLIC_APP_URL}/inventory/${inventoryId}/fill`,
+      qrCodeUrl: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard/inventory/${inventoryId}/fill`,
       signature: null,
       photos: [],
       createdAt: new Date(),

--- a/app/dashboard/deposits/page.js
+++ b/app/dashboard/deposits/page.js
@@ -46,7 +46,7 @@ export default function DepositsPage() {
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <Link
-            href="dashboard/deposits/perceived"
+            href="/dashboard/deposits/perceived"
             className="card group p-5 flex flex-col justify-between hover:border-primary-200 transition"
           >
             <div className="flex items-center justify-between">

--- a/app/dashboard/guests/new/page.js
+++ b/app/dashboard/guests/new/page.js
@@ -55,7 +55,7 @@ export default function NewGuestPage() {
                 des documents et automatiser la communication avant leur arrivée.
               </p>
               <button
-                onClick={() => router.push('/guests')}
+                onClick={() => router.push('/dashboard/guests')}
                 className="mt-4 btn-secondary"
               >
                 Retour à la liste des invités

--- a/app/dashboard/guidebook/page.js
+++ b/app/dashboard/guidebook/page.js
@@ -206,7 +206,7 @@ export default function GuidebookPage() {
       };
 
       const encoded = encodeGuideData(payload);
-      const url = `${window.location.origin}/guidebook/view?data=${encodeURIComponent(encoded)}`;
+      const url = `${window.location.origin}/dashboard/guidebook/view?data=${encodeURIComponent(encoded)}`;
       const qr = await QRCode.toDataURL(url, {
         margin: 1,
         width: 480,

--- a/app/dashboard/inventory/[id]/edit/page.js
+++ b/app/dashboard/inventory/[id]/edit/page.js
@@ -300,7 +300,7 @@ export default function EditInventoryPage() {
       }
 
       setSubmitMessage('Inventaire mis à jour avec succès');
-      router.push(`/inventory/${inventoryId}`);
+      router.push(`/dashboard/inventory/${inventoryId}`);
     } catch (error) {
       console.error('Error updating inventory', error);
       setErrors({ submit: error.message });
@@ -709,7 +709,7 @@ export default function EditInventoryPage() {
             <div className="flex items-center justify-end space-x-4">
               <button
                 type="button"
-                onClick={() => router.push(`/inventory/${inventoryId}`)}
+                onClick={() => router.push(`/dashboard/inventory/${inventoryId}`)}
                 className="btn-secondary"
                 disabled={isSubmitting}
               >

--- a/app/dashboard/inventory/[id]/page.js
+++ b/app/dashboard/inventory/[id]/page.js
@@ -168,7 +168,7 @@ export default function InventoryDetailsPage() {
 
           {inventory && (
             <button
-              onClick={() => router.push(`/inventory/${inventoryId}/edit`)}
+              onClick={() => router.push(`/dashboard/inventory/${inventoryId}/edit`)}
               className="btn-primary inline-flex items-center"
             >
               <Edit className="h-4 w-4 mr-2" />
@@ -195,7 +195,7 @@ export default function InventoryDetailsPage() {
                 Vérifiez l&apos;identifiant ou retournez à la liste des inventaires.
               </p>
             <button
-              onClick={() => router.push('/inventory')}
+              onClick={() => router.push('/dashboard/inventory')}
               className="btn-primary"
             >
               Retour à la liste

--- a/app/dashboard/inventory/new/page.js
+++ b/app/dashboard/inventory/new/page.js
@@ -198,7 +198,7 @@ export default function NewInventoryPage() {
 
       if (response.ok) {
         const inventory = await response.json();
-        router.push(`/inventory/${inventory.id}`);
+        router.push(`/dashboard/inventory/${inventory.id}`);
       } else {
         const error = await response.json();
         setErrors({ submit: error.message || 'Erreur lors de la création' });

--- a/app/dashboard/inventory/page.js
+++ b/app/dashboard/inventory/page.js
@@ -82,15 +82,15 @@ export default function InventoryPage() {
   };
 
   const handleCreateInventory = () => {
-    router.push('/inventory/new');
+    router.push('/dashboard/inventory/new');
   };
 
   const handleViewInventory = (inventory) => {
-    router.push(`/inventory/${inventory.id}`);
+    router.push(`/dashboard/inventory/${inventory.id}`);
   };
 
   const handleEditInventory = (inventory) => {
-    router.push(`/inventory/${inventory.id}/edit`);
+    router.push(`/dashboard/inventory/${inventory.id}/edit`);
   };
 
   const handleDuplicateInventory = async (inventory) => {

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -125,7 +125,7 @@ export default function DashboardPage() {
   const handleQuickAction = (action) => {
     switch (action) {
       case 'new-inventory':
-        router.push('/inventory/new');
+        router.push('/dashboard/inventory/new');
         break;
       case 'new-guest':
         router.push('/dashboard/guests');

--- a/app/dashboard/properties/[id]/page.js
+++ b/app/dashboard/properties/[id]/page.js
@@ -706,8 +706,8 @@ export default function PropertyDetailsPage() {
     return matches.length >= 2 ? `${matches[0]}${matches[1]}` : matches[0] || initialsSource.charAt(0).toUpperCase();
   }, [ownerProfile]);
 
-  const handleGoBack = () => router.push('/properties');
-  const handleOpenSettings = () => property?.id && router.push(`/properties/${property.id}/settings`);
+  const handleGoBack = () => router.push('/dashboard/properties');
+  const handleOpenSettings = () => property?.id && router.push(`/dashboard/properties/${property.id}/settings`);
   const handleOpenCalendar = () => property?.id && router.push(`/dashboard/calendrier?property=${property.id}`);
   const handlePublish = () => miniSiteUrl && window.open(miniSiteUrl, '_blank', 'noopener,noreferrer');
 

--- a/app/dashboard/properties/[id]/settings/page.js
+++ b/app/dashboard/properties/[id]/settings/page.js
@@ -98,7 +98,7 @@ export default function PropertySettingsPage() {
   }, [propertyId, router, token]);
 
   const handleGoBack = () => {
-    router.push(property ? `/properties/${property.id}` : '/properties');
+    router.push(property ? `/dashboard/properties/${property.id}` : '/dashboard/properties');
   };
 
   const handleInputChange = (event) => {

--- a/app/dashboard/properties/page.js
+++ b/app/dashboard/properties/page.js
@@ -240,12 +240,12 @@ export default function DashboardPropertiesPage() {
                 key={property.id}
                 property={property}
                 onEdit={handleEditProperty}
-                onView={(currentProperty) => router.push(`/properties/${currentProperty.id}`)}
+                onView={(currentProperty) => router.push(`/dashboard/properties/${currentProperty.id}`)}
                 onCalendar={(currentProperty) =>
                   router.push(`/dashboard/calendrier?property=${currentProperty.id}`)
                 }
                 onSettings={(currentProperty) =>
-                  router.push(`/properties/${currentProperty.id}/settings`)
+                  router.push(`/dashboard/properties/${currentProperty.id}/settings`)
                 }
                 onDelete={handleDeleteProperty}
               />

--- a/app/dashboard/super-admin/page.js
+++ b/app/dashboard/super-admin/page.js
@@ -398,13 +398,13 @@ export default function SuperAdminDashboard() {
   const handleQuickAction = (actionId) => {
     switch (actionId) {
       case 'billing':
-        router.push('/settings');
+        router.push('/dashboard/settings');
         break;
       case 'growth':
         router.push('/dashboard');
         break;
       case 'support':
-        router.push('/settings');
+        router.push('/dashboard/settings');
         break;
       case 'onboarding':
         router.push('/dashboard/properties');

--- a/components/DashboardLayout.js
+++ b/components/DashboardLayout.js
@@ -78,22 +78,22 @@ export default function DashboardLayout({ children }) {
   const baseNavigation = [
     { name: 'Dashboard', href: '/dashboard', icon: Home },
     { name: 'Propriétés', href: '/dashboard/properties', icon: Building2 },
-    { name: 'Inventaires', href: '/inventory', icon: FileText },
+    { name: 'Inventaires', href: '/dashboard/inventory', icon: FileText },
     { name: 'Guests', href: '/dashboard/guests', icon: Users },
     { name: 'Cautions', href: '/dashboard/deposits', icon: CreditCard },
     { name: 'Calendrier', href: '/dashboard/calendrier', icon: Calendar },
-    { name: "Guide d'arrivée", href: '/guidebook', icon: BookOpen },
-    { name: 'Paramètres', href: '/settings', icon: Settings },
+    { name: "Guide d'arrivée", href: '/dashboard/guidebook', icon: BookOpen },
+    { name: 'Paramètres', href: '/dashboard/settings', icon: Settings },
   ];
 
   const baseMobileNavigation = [
     { name: 'Dashboard', href: '/dashboard', icon: Home },
     { name: 'Propriétés', href: '/dashboard/properties', icon: Building2 },
-    { name: 'Inventaires', href: '/inventory', icon: FileText },
+    { name: 'Inventaires', href: '/dashboard/inventory', icon: FileText },
     { name: 'Guests', href: '/dashboard/guests', icon: Users },
     { name: 'Cautions', href: '/dashboard/deposits', icon: CreditCard },
     { name: 'Calendrier', href: '/dashboard/calendrier', icon: Calendar },
-    { name: "Guide d'arrivée", href: '/guidebook', icon: BookOpen },
+    { name: "Guide d'arrivée", href: '/dashboard/guidebook', icon: BookOpen },
   ];
 
   const superAdminEntry = {
@@ -174,7 +174,7 @@ export default function DashboardLayout({ children }) {
               {isProfileDropdownOpen && (
                 <div className="absolute bottom-full left-0 right-0 mb-2 bg-white rounded-lg shadow-lg border border-gray-200 py-1">
                   <Link
-                    href="/settings/profile"
+                    href="/dashboard/settings/profile"
                     className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
                     onClick={() => setIsProfileDropdownOpen(false)}
                   >
@@ -182,7 +182,7 @@ export default function DashboardLayout({ children }) {
                     Mon profil
                   </Link>
                   <Link
-                    href="/settings"
+                    href="/dashboard/settings"
                     className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
                     onClick={() => setIsProfileDropdownOpen(false)}
                   >

--- a/components/WelcomeModal.js
+++ b/components/WelcomeModal.js
@@ -16,19 +16,19 @@ export default function WelcomeModal({ onClose }) {
       title: 'Créez vos inventaires',
       content: 'Commencez par créer des inventaires détaillés pour chacune de vos propriétés. Ajoutez des photos, notations et commentaires.',
       action: 'Créer un inventaire',
-      href: '/inventory/new'
+      href: '/dashboard/inventory/new'
     },
     {
       title: 'Gérez vos guests',
       content: 'Ajoutez vos invités, suivez leurs séjours et automatisez le processus de check-in/check-out avec QR codes.',
       action: 'Ajouter un guest',
-      href: '/guests/new'
+      href: '/dashboard/guests/new'
     },
     {
       title: 'Configurez Stripe',
       content: 'Connectez votre compte Stripe pour gérer automatiquement les cautions et pré-autorisations.',
       action: 'Configurer Stripe',
-      href: '/settings/payments'
+      href: '/dashboard/settings'
     }
   ];
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -36,7 +36,7 @@
       "name": "Nouvel inventaire",
       "short_name": "Inventaire",
       "description": "Créer un nouvel inventaire",
-      "url": "/inventory/new",
+      "url": "/dashboard/inventory/new",
       "icons": [{ "src": "/icons/inventory.png", "sizes": "96x96" }]
     }
   ]

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,9 +8,9 @@ Allow: /legal/privacy
 Allow: /legal/terms
 
 Disallow: /dashboard
-Disallow: /inventory
-Disallow: /guests
-Disallow: /deposits
+Disallow: /dashboard/inventory
+Disallow: /dashboard/guests
+Disallow: /dashboard/deposits
 Disallow: /api/
 Disallow: /admin
 Disallow: /auth

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,9 +2,9 @@ const CACHE_NAME = 'checkinly-v1.0.0';
 const urlsToCache = [
   '/',
   '/dashboard',
-  '/inventory',
-  '/guests',
-  '/deposits',
+  '/dashboard/inventory',
+  '/dashboard/guests',
+  '/dashboard/deposits',
   '/offline',
   '/manifest.json',
   '/icons/icon-192x192.png',


### PR DESCRIPTION
## Summary
- update dashboard navigation, modals, and pages to point to the /dashboard/* routes
- refresh API link generation, manifest shortcuts, and service worker cache lists with the new dashboard URLs
- adjust guestbook sharing and deposit links plus robots.txt disallow rules for the dashboard paths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69e54e888832eafe6b15ee91ed0b4