### PR TITLE
Add edit flow for arrival guides

### DIFF
--- a/app/api/guides/[id]/route.js
+++ b/app/api/guides/[id]/route.js
@@ -169,3 +169,26 @@ export async function DELETE(_, { params }) {
     return NextResponse.json({ message: 'Impossible de supprimer le guide.' }, { status: 500 });
   }
 }
+
+export async function GET(_, { params }) {
+  const { id } = params;
+  const objectId = parseId(id);
+
+  if (!objectId) {
+    return NextResponse.json({ message: 'Identifiant invalide.' }, { status: 400 });
+  }
+
+  try {
+    const { db } = await connectDB();
+    const doc = await db.collection('arrival_guides').findOne({ _id: objectId });
+
+    if (!doc) {
+      return NextResponse.json({ message: 'Guide introuvable.' }, { status: 404 });
+    }
+
+    return NextResponse.json(serializeGuide(doc));
+  } catch (error) {
+    console.error('GET /api/guides/[id] error:', error);
+    return NextResponse.json({ message: 'Impossible de récupérer le guide.' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add a GET handler to `/api/guides/[id]` so the dashboard can fetch full guide details
- extend the guidebook dashboard page with a Modify button that opens an edit modal
- upgrade the existing guide modal to support editing in addition to creation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7a7b821e8832e9f6b36f14964e1fb