### PR TITLE
Add Stripe deposit capture and refund APIs

### DIFF
--- a/app/api/deposits/[id]/route.js
+++ b/app/api/deposits/[id]/route.js
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import { ObjectId } from 'mongodb';
+import { getCollections } from '@/lib/mongo';
+import { deleteDeposit, refundDeposit } from '@/lib/deposits';
+import logger from '@/lib/logger';
+
+function serialize(doc) {
+  if (!doc) return null;
+  return {
+    ...doc,
+    _id: doc._id?.toString(),
+    guest_id: doc.guest_id ? doc.guest_id.toString() : null,
+    property_id: doc.property_id ? doc.property_id.toString() : null,
+    refunds: Array.isArray(doc.refunds)
+      ? doc.refunds.map((entry) => ({
+          ...entry,
+          created_at: entry.created_at instanceof Date ? entry.created_at.toISOString() : entry.created_at,
+        }))
+      : [],
+    created_at: doc.created_at instanceof Date ? doc.created_at.toISOString() : doc.created_at,
+    updated_at: doc.updated_at instanceof Date ? doc.updated_at.toISOString() : doc.updated_at,
+  };
+}
+
+export async function GET(_request, { params }) {
+  try {
+    const depositId = params.id;
+    if (!depositId || !ObjectId.isValid(depositId)) {
+      return NextResponse.json({ error: 'Deposit introuvable' }, { status: 404 });
+    }
+    const { deposits } = await getCollections();
+    const deposit = await deposits.findOne({ _id: new ObjectId(depositId) });
+    if (!deposit) {
+      return NextResponse.json({ error: 'Deposit introuvable' }, { status: 404 });
+    }
+    return NextResponse.json(serialize(deposit));
+  } catch (error) {
+    logger.error(`GET /api/deposits/${params.id} failed`, error);
+    return NextResponse.json({ error: error.message || 'Requête invalide' }, { status: 400 });
+  }
+}
+
+export async function POST(request, { params }) {
+  try {
+    const action = request.nextUrl.searchParams.get('action');
+    if (action !== 'refund') {
+      return NextResponse.json({ error: 'Action inconnue' }, { status: 400 });
+    }
+    const payload = await request.json();
+    const result = await refundDeposit({ depositId: params.id, ...(payload || {}) });
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.error(`POST /api/deposits/${params.id} failed`, error);
+    return NextResponse.json({ error: error.message || 'Requête invalide' }, { status: 400 });
+  }
+}
+
+export async function DELETE(_request, { params }) {
+  try {
+    const result = await deleteDeposit({ depositId: params.id });
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.error(`DELETE /api/deposits/${params.id} failed`, error);
+    return NextResponse.json({ error: error.message || 'Requête invalide' }, { status: 400 });
+  }
+}
+
+/*
+Rembourser partiellement un deposit :
+fetch('/api/deposits/64f...abc?action=refund', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ amount: 20000, reason: 'Fin de séjour' })
+});
+*/

--- a/app/api/deposits/route.js
+++ b/app/api/deposits/route.js
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { createCapturedDeposit, listDeposits } from '@/lib/deposits';
+import logger from '@/lib/logger';
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const result = await listDeposits({
+      q: searchParams.get('q') || undefined,
+      propertyId: searchParams.get('propertyId') || undefined,
+      guestId: searchParams.get('guestId') || undefined,
+      status: searchParams.get('status') || undefined,
+      minAmount: searchParams.get('minAmount') || undefined,
+      maxAmount: searchParams.get('maxAmount') || undefined,
+      dateFrom: searchParams.get('dateFrom') || undefined,
+      dateTo: searchParams.get('dateTo') || undefined,
+      page: searchParams.get('page') || undefined,
+      pageSize: searchParams.get('pageSize') || undefined,
+      expand: searchParams.get('expand') || undefined,
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    logger.error('GET /api/deposits failed', error);
+    return NextResponse.json({ error: error.message || 'Requête invalide' }, { status: 400 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const payload = await request.json();
+    const deposit = await createCapturedDeposit(payload || {});
+    return NextResponse.json(deposit, { status: 201 });
+  } catch (error) {
+    logger.error('POST /api/deposits failed', error);
+    return NextResponse.json({ error: error.message || 'Requête invalide' }, { status: 400 });
+  }
+}
+
+/*
+Exemple création d'un deposit :
+fetch('/api/deposits', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    amount: 50000,
+    currency: 'eur',
+    guestId: '<ObjectId guest>',
+    propertyId: '<ObjectId property>',
+    description: 'Deposit séjour Chalet ...',
+    paymentMethodId: 'pm_***',
+    // customerId: 'cus_***'
+  })
+});
+
+Exemple de listing paginé avec expansions :
+fetch('/api/deposits?status=captured&page=1&pageSize=20&expand=guest,property');
+*/

--- a/app/api/stripe/webhook/route.js
+++ b/app/api/stripe/webhook/route.js
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import stripe from '@/lib/stripe';
+import { getCollections } from '@/lib/mongo';
+import logger from '@/lib/logger';
+
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+if (!webhookSecret) {
+  throw new Error('STRIPE_WEBHOOK_SECRET manquant');
+}
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const config = { api: { bodyParser: false } }; // Node runtime dans Next 15 conserve request.text() intact
+
+async function syncRefundedCharge(charge) {
+  const { deposits } = await getCollections();
+  const deposit = await deposits.findOne({ stripe_charge_id: charge.id });
+  if (!deposit) {
+    return;
+  }
+
+  const refunds = Array.isArray(charge.refunds?.data)
+    ? charge.refunds.data.map((refund) => ({
+        stripe_refund_id: refund.id,
+        amount: refund.amount,
+        reason: refund.reason || null,
+        created_at: refund.created ? new Date(refund.created * 1000) : new Date(),
+      }))
+    : deposit.refunds;
+
+  const refundableRemaining = Math.max(0, deposit.amount - (charge.amount_refunded || 0));
+  let status = deposit.status;
+  if (refundableRemaining === 0) {
+    status = 'refunded';
+  } else if (refundableRemaining < deposit.amount) {
+    status = 'partially_refunded';
+  }
+
+  await deposits.updateOne(
+    { _id: deposit._id },
+    {
+      $set: {
+        refundable_remaining: refundableRemaining,
+        status,
+        refunds,
+        updated_at: new Date(),
+      },
+    }
+  );
+}
+
+export async function POST(request) {
+  const signature = request.headers.get('stripe-signature');
+  if (!signature) {
+    return NextResponse.json({ error: 'Signature manquante' }, { status: 400 });
+  }
+
+  const payload = await request.text();
+  let event;
+
+  try {
+    event = stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+  } catch (error) {
+    logger.error('Webhook Stripe invalide', error);
+    return NextResponse.json({ error: `Webhook invalide: ${error.message}` }, { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case 'charge.refunded':
+        await syncRefundedCharge(event.data.object);
+        break;
+      case 'payment_intent.succeeded':
+        // Synchronisation optionnelle si nécessaire
+        break;
+      default:
+        break;
+    }
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    logger.error('Traitement webhook Stripe échoué', error);
+    return NextResponse.json({ error: error.message || 'Erreur interne' }, { status: 500 });
+  }
+}

--- a/lib/deposits.js
+++ b/lib/deposits.js
@@ -1,0 +1,336 @@
+import { ObjectId } from 'mongodb';
+import { getCollections } from './mongo';
+import stripe from './stripe';
+// import logger from './logger';
+
+function ensureObjectId(value, errorMessage) {
+  if (!value || !ObjectId.isValid(value)) {
+    throw new Error(errorMessage);
+  }
+  return new ObjectId(value);
+}
+
+function serializeDeposit(doc) {
+  if (!doc) return null;
+  const serialized = {
+    ...doc,
+    _id: doc._id?.toString(),
+    guest_id: doc.guest_id ? doc.guest_id.toString() : null,
+    property_id: doc.property_id ? doc.property_id.toString() : null,
+    refunds: Array.isArray(doc.refunds)
+      ? doc.refunds.map((entry) => ({
+          ...entry,
+          created_at: entry.created_at instanceof Date ? entry.created_at.toISOString() : entry.created_at,
+        }))
+      : [],
+    created_at: doc.created_at instanceof Date ? doc.created_at.toISOString() : doc.created_at,
+    updated_at: doc.updated_at instanceof Date ? doc.updated_at.toISOString() : doc.updated_at,
+  };
+  if (doc.guest && doc.guest._id) {
+    serialized.guest = {
+      ...doc.guest,
+      _id: doc.guest._id.toString(),
+    };
+  }
+  if (doc.property && doc.property._id) {
+    serialized.property = {
+      ...doc.property,
+      _id: doc.property._id.toString(),
+    };
+  }
+  return serialized;
+}
+
+export async function assertRefs({ guestId, propertyId }) {
+  const { guests, properties } = await getCollections();
+  const guestObjectId = ensureObjectId(guestId, 'Guest introuvable');
+  const propertyObjectId = ensureObjectId(propertyId, 'Property introuvable');
+
+  const [guest, property] = await Promise.all([
+    guests.findOne({ _id: guestObjectId }, { projection: { _id: 1 } }),
+    properties.findOne({ _id: propertyObjectId }, { projection: { _id: 1 } }),
+  ]);
+
+  if (!guest) {
+    throw new Error('Guest introuvable');
+  }
+
+  if (!property) {
+    throw new Error('Property introuvable');
+  }
+
+  return { guestObjectId, propertyObjectId };
+}
+
+export async function createCapturedDeposit({
+  amount,
+  currency = 'eur',
+  guestId,
+  propertyId,
+  description = '',
+  paymentMethodId,
+  customerId,
+}) {
+  if (!amount || Number(amount) <= 0) {
+    throw new Error('Montant invalide');
+  }
+
+  if (!paymentMethodId) {
+    throw new Error('paymentMethodId requis');
+  }
+
+  const normalizedAmount = Math.round(Number(amount));
+  const { guestObjectId, propertyObjectId } = await assertRefs({ guestId, propertyId });
+
+  const paymentIntentPayload = {
+    amount: normalizedAmount,
+    currency,
+    confirm: true,
+    capture_method: 'automatic',
+    payment_method: paymentMethodId,
+    description: description || undefined,
+  };
+
+  if (customerId) {
+    paymentIntentPayload.customer = customerId;
+  }
+
+  const paymentIntent = await stripe.paymentIntents.create(paymentIntentPayload);
+  const chargeId = paymentIntent.latest_charge || (paymentIntent.charges?.data?.[0]?.id ?? null);
+
+  const now = new Date();
+  const depositDocument = {
+    amount: normalizedAmount,
+    currency,
+    status: 'captured',
+    stripe_payment_intent_id: paymentIntent.id,
+    stripe_charge_id: chargeId,
+    property_id: propertyObjectId,
+    guest_id: guestObjectId,
+    description: description || '',
+    created_at: now,
+    updated_at: now,
+    refunds: [],
+    refundable_remaining: normalizedAmount,
+  };
+
+  const { deposits } = await getCollections();
+  const insertResult = await deposits.insertOne(depositDocument);
+
+  return serializeDeposit({ ...depositDocument, _id: insertResult.insertedId });
+}
+
+export async function refundDeposit({ depositId, amount, reason }) {
+  const { deposits } = await getCollections();
+  const targetId = ensureObjectId(depositId, 'Deposit introuvable');
+  const deposit = await deposits.findOne({ _id: targetId });
+
+  if (!deposit) {
+    throw new Error('Deposit introuvable');
+  }
+
+  if (!deposit.refundable_remaining || deposit.refundable_remaining <= 0) {
+    throw new Error('Plus rien à rembourser');
+  }
+
+  const refundAmount = amount != null ? Math.round(Number(amount)) : deposit.refundable_remaining;
+
+  if (!refundAmount || refundAmount <= 0 || refundAmount > deposit.refundable_remaining) {
+    throw new Error('Montant invalide');
+  }
+
+  const refund = await stripe.refunds.create({
+    charge: deposit.stripe_charge_id,
+    amount: refundAmount,
+    reason: reason || undefined,
+  });
+
+  const remaining = Math.max(0, deposit.refundable_remaining - refundAmount);
+  const status = remaining === 0 ? 'refunded' : 'partially_refunded';
+  const refundEntry = {
+    stripe_refund_id: refund.id,
+    amount: refundAmount,
+    reason: reason || null,
+    created_at: refund.created ? new Date(refund.created * 1000) : new Date(),
+  };
+
+  await deposits.updateOne(
+    { _id: targetId },
+    {
+      $set: {
+        refundable_remaining: remaining,
+        status,
+        updated_at: new Date(),
+      },
+      $push: { refunds: refundEntry },
+    }
+  );
+
+  return { ok: true, refund_id: refund.id, refundable_remaining: remaining, status };
+}
+
+export async function listDeposits({
+  q,
+  propertyId,
+  guestId,
+  status,
+  minAmount,
+  maxAmount,
+  dateFrom,
+  dateTo,
+  page = 1,
+  pageSize = 20,
+  expand,
+} = {}) {
+  const { deposits } = await getCollections();
+  const filter = {};
+
+  if (q) {
+    filter.description = { $regex: q, $options: 'i' };
+  }
+
+  if (propertyId) {
+    filter.property_id = ensureObjectId(propertyId, 'Property introuvable');
+  }
+
+  if (guestId) {
+    filter.guest_id = ensureObjectId(guestId, 'Guest introuvable');
+  }
+
+  if (status) {
+    filter.status = status;
+  }
+
+  if (minAmount || maxAmount) {
+    filter.amount = {};
+    if (minAmount) {
+      filter.amount.$gte = Math.round(Number(minAmount));
+    }
+    if (maxAmount) {
+      filter.amount.$lte = Math.round(Number(maxAmount));
+    }
+  }
+
+  if (dateFrom || dateTo) {
+    filter.created_at = {};
+    if (dateFrom) {
+      const fromDate = new Date(dateFrom);
+      if (!Number.isNaN(fromDate.getTime())) {
+        filter.created_at.$gte = fromDate;
+      }
+    }
+    if (dateTo) {
+      const toDate = new Date(dateTo);
+      if (!Number.isNaN(toDate.getTime())) {
+        filter.created_at.$lte = toDate;
+      }
+    }
+  }
+
+  const safePage = Math.max(1, parseInt(page, 10) || 1);
+  const safePageSize = Math.min(100, Math.max(1, parseInt(pageSize, 10) || 20));
+  const skip = (safePage - 1) * safePageSize;
+
+  const expandSet = new Set();
+  if (typeof expand === 'string') {
+    expand
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .forEach((item) => expandSet.add(item));
+  }
+
+  const pipeline = [{ $match: filter }, { $sort: { created_at: -1 } }, { $skip: skip }, { $limit: safePageSize }];
+
+  if (expandSet.has('guest')) {
+    pipeline.push(
+      {
+        $lookup: {
+          from: 'guests',
+          localField: 'guest_id',
+          foreignField: '_id',
+          as: 'guest_data',
+        },
+      },
+      {
+        $unwind: {
+          path: '$guest_data',
+          preserveNullAndEmptyArrays: true,
+        },
+      },
+      {
+        $addFields: {
+          guest: '$guest_data',
+          guest_name: {
+            $trim: {
+              input: {
+                $concat: [
+                  { $ifNull: ['$guest_data.first_name', ''] },
+                  ' ',
+                  { $ifNull: ['$guest_data.last_name', ''] },
+                ],
+              },
+            },
+          },
+        },
+      },
+      {
+        $project: {
+          guest_data: 0,
+        },
+      }
+    );
+  }
+
+  if (expandSet.has('property')) {
+    pipeline.push(
+      {
+        $lookup: {
+          from: 'properties',
+          localField: 'property_id',
+          foreignField: '_id',
+          as: 'property_data',
+        },
+      },
+      {
+        $unwind: {
+          path: '$property_data',
+          preserveNullAndEmptyArrays: true,
+        },
+      },
+      {
+        $addFields: {
+          property: '$property_data',
+          property_title: '$property_data.title',
+        },
+      },
+      {
+        $project: {
+          property_data: 0,
+        },
+      }
+    );
+  }
+
+  const [items, total] = await Promise.all([
+    deposits.aggregate(pipeline).toArray(),
+    deposits.countDocuments(filter),
+  ]);
+
+  const totalPages = total === 0 ? 0 : Math.ceil(total / safePageSize);
+
+  return {
+    items: items.map(serializeDeposit),
+    page: safePage,
+    pageSize: safePageSize,
+    total,
+    totalPages,
+  };
+}
+
+export async function deleteDeposit({ depositId }) {
+  const { deposits } = await getCollections();
+  const targetId = ensureObjectId(depositId, 'Deposit introuvable');
+  await deposits.deleteOne({ _id: targetId });
+  return { ok: true };
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,24 @@
+const LEVELS = ['debug', 'info', 'warn', 'error'];
+
+function format(level, messages) {
+  const ts = new Date().toISOString();
+  return [`[deposits:${level}]`, ts, ...messages];
+}
+
+const logger = LEVELS.reduce((acc, level) => {
+  acc[level] = (...messages) => {
+    const formatted = format(level, messages);
+    if (level === 'error') {
+      console.error(...formatted);
+    } else if (level === 'warn') {
+      console.warn(...formatted);
+    } else if (level === 'info') {
+      console.info(...formatted);
+    } else {
+      console.debug(...formatted);
+    }
+  };
+  return acc;
+}, {});
+
+export default logger;

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -1,0 +1,53 @@
+import { MongoClient } from 'mongodb';
+
+const uri = process.env.MONGODB_URI;
+
+if (!uri) {
+  throw new Error('MONGODB_URI manquant');
+}
+
+let client;
+let clientPromise;
+
+function getDatabaseNameFromUri(connectionUri) {
+  const url = new URL(connectionUri);
+  const pathname = url.pathname.replace(/^\//, '');
+  if (!pathname) {
+    throw new Error('Le nom de base doit être présent dans MONGODB_URI');
+  }
+  return decodeURIComponent(pathname);
+}
+
+const dbName = getDatabaseNameFromUri(uri);
+
+function getClientOptions() {
+  return {
+    maxPoolSize: 10,
+    minPoolSize: 0,
+    serverSelectionTimeoutMS: 5000,
+  };
+}
+
+function getClient() {
+  if (!clientPromise) {
+    client = new MongoClient(uri, getClientOptions());
+    clientPromise = client.connect();
+  }
+  return clientPromise;
+}
+
+export async function getDb() {
+  const mongoClient = await getClient();
+  return mongoClient.db(dbName);
+}
+
+export async function getCollections() {
+  const db = await getDb();
+  return {
+    guests: db.collection('guests'),
+    properties: db.collection('properties'),
+    deposits: db.collection('deposits'),
+  };
+}
+
+export default getClient;

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -1,0 +1,14 @@
+import Stripe from 'stripe';
+
+const secretKey = process.env.STRIPE_SECRET_KEY;
+
+if (!secretKey) {
+  throw new Error('STRIPE_SECRET_KEY manquant');
+}
+
+const stripe = new Stripe(secretKey, {
+  apiVersion: '2024-06-20',
+});
+
+export default stripe;
+export { stripe };


### PR DESCRIPTION
## Summary
- add MongoDB, Stripe, and logging utilities to support deposit workflows
- implement deposit service logic for creation, listing, refunds, and deletion
- expose REST endpoints for deposits management and Stripe webhook synchronisation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8d65b802c832e82f982e1ca030352